### PR TITLE
Make library functions internal

### DIFF
--- a/implementation/contracts/StackLib.sol
+++ b/implementation/contracts/StackLib.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.10;
 
 library StackLib {
 
-    function stackPeek(uint256[] storage _array) public view returns (uint256){
+    function stackPeek(uint256[] storage _array) internal view returns (uint256){
        require(_array.length > 0,"No value to peek, array is empty");
        return(_array[_array.length - 1]);
     }
@@ -11,14 +11,14 @@ library StackLib {
        _array.push(_element);
     }
 
-    function stackPop(uint256[] storage _array) public returns (uint256){
+    function stackPop(uint256[] storage _array) internal returns (uint256){
         require(_array.length > 0,"No value to pop, array is empty");
         uint256 value = _array[_array.length - 1];
         _array.length -= 1;
         return value;
     }
 
-    function getSize(uint256[] storage _array) public view returns (uint256){
+    function getSize(uint256[] storage _array) internal view returns (uint256){
         return _array.length;
     }
 }


### PR DESCRIPTION
internal library functions are cheaper to call.
This saves ~6k gas per call to insert.