### PR TITLE
Updated function state mutability restrictions, eliminated ABIEncoderV2

### DIFF
--- a/contracts/Sortition.sol
+++ b/contracts/Sortition.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.5.10;
-pragma experimental ABIEncoderV2;
 
 import './StackLib.sol';
 import './Branch.sol';

--- a/test/contracts/BranchStub.sol
+++ b/test/contracts/BranchStub.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.5.10;
-pragma experimental ABIEncoderV2;
 
 import '../../contracts/Branch.sol';
 

--- a/test/contracts/PositionStub.sol
+++ b/test/contracts/PositionStub.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.5.10;
-pragma experimental ABIEncoderV2;
 
 import '../../contracts/Position.sol';
 

--- a/test/contracts/StackStub.sol
+++ b/test/contracts/StackStub.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.5.10;
-pragma experimental ABIEncoderV2;
 
 import '../../contracts/Sortition.sol';
 contract StackStub is Sortition {


### PR DESCRIPTION
~~Depends on #18~~

Refs: keep-network/keep-tecdsa#137

Two changes:
- Updated function state mutability restrictions updated to eliminate `solc` warnings
- Eliminated `ABIEncoderV2` pragma - until Solidity `0.6.0` `ABIEncoderV2` is experimental and should not be used for production deployments