### PR TITLE
package.json - updated name and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
~~Depends on #18~~ 

Refs: keep-network/keep-tecdsa#137

Added `@keep-network` scope to the package name.

https://docs.npmjs.com/misc/scope says:

> Each npm user/organization has their own scope, and only you can add packages in your scope. This means you don’t have to worry about someone taking your package name ahead of you. Thus it is also a good way to signal official packages for organizations.

Changed version to `0.1.0`. We are still in a rapid development phase and API may change. According to https://semver.org/ rules, it is best if we stay as `0.y.z` for now.