### PR TITLE
GitHub’s syntax highlighting for Solidity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
GitHub doesn’t support detecting .sol files as Solidity for syntax highlighting, here we fix it.

For more information please see: https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6