### PR TITLE
Included contracts only in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "contracts/**/*.sol"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "test": "NODE_ENV=test truffle test"
   },


### PR DESCRIPTION
We include only `.sol` contracts in the npm package. We don't need to export other parts of this repository like tests and deployment configuration.