### PR TITLE
Only owner may select signers from a pool

### DIFF
--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -67,6 +67,8 @@ contract BondedSortitionPool is AbstractSortitionPool {
         bytes32 seed,
         uint256 bondValue
     ) public returns (address[] memory) {
+        require(msg.sender == poolOwner, "Only owner may select groups");
+
         uint256 selectedTotalWeight = root;
         PoolParams memory params = PoolParams(
             staking,

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -35,6 +35,8 @@ contract SortitionPool is AbstractSortitionPool {
     function selectGroup(
         uint256 groupSize, bytes32 seed
     ) public returns (address[] memory)  {
+        require(msg.sender == poolOwner, "Only owner may select groups");
+
         uint256 _root = root;
         bool _rootChanged = false;
         uint256 poolWeight = _root.sumWeight();


### PR DESCRIPTION
When signers are selected, the pool state may change. Sortition tree root is potentially updated both for the bonded and non-bonded variant. For bonded variant, the minimum bondable value gets updated.

To avoid a third party manipulating these parameters, we allow only owner to select signers from a pool.