### PR TITLE
Branch gas optimisations 

### DIFF
--- a/contracts/Branch.sol
+++ b/contracts/Branch.sol
@@ -94,14 +94,15 @@ library Branch {
     }
 
     /// @notice Calculate the summed weight of all slots in the `node`.
-    function sumWeight(uint256 node) internal pure returns (uint256) {
-        uint256 sum;
-
-        for (uint256 i = 0; i < SLOT_COUNT; i++) {
-            // Iterate through each slot
-            // by shifting `node` right in increments of 32 bits,
-            // and adding the 32 least significant bits to the `sum`.
-            sum += (node >> (i * SLOT_WIDTH)) & SLOT_MAX;
+    function sumWeight(uint256 node) internal pure returns (uint256 sum) {
+        sum = node & SLOT_MAX;
+        // Iterate through each slot
+        // by shifting `node` right in increments of 32 bits,
+        // and adding the 32 least significant bits to the `sum`.
+        uint256 newNode = node >> SLOT_WIDTH;
+        while (newNode > 0) {
+            sum += (newNode & SLOT_MAX);
+            newNode = newNode >> SLOT_WIDTH;
         }
         return sum;
     }


### PR DESCRIPTION
This PR contains two `Branch` gas cost optimizations extracted from #57. 

I intentionally moved them to a separate PR to have a clear view of what's going to the `master`. 

Init blocks and only-owner-selects restrictions from #57 have been pulled into #60 and #59 respectively. After this PR is merged we can close #57.