### PR TITLE
Add activeStake function to IStaking

### DIFF
--- a/contracts/api/IStaking.sol
+++ b/contracts/api/IStaking.sol
@@ -11,4 +11,15 @@ interface IStaking {
         address operator,
         address operatorContract
     ) external view returns (uint256);
+
+    // Gives the amount of KEEP tokens staked by the `operator`
+    // active in the specified `operatorContract`.
+    //
+    // If the operator doesn't exist or hasn't finished initializing,
+    // or the operator contract hasn't been authorized for the operator,
+    // returns 0.
+    function activeStake(
+        address operator,
+        address operatorContract
+    ) external view returns (uint256);
 }


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-tecdsa/pull/192

This PR adds `activeStake` function to the `IStaking` interface. This function is needed to perform minum stake checks.