### PR TITLE
Reduce the cost of initialization queries during group selection

### DIFF
--- a/contracts/AbstractSortitionPool.sol
+++ b/contracts/AbstractSortitionPool.sol
@@ -86,9 +86,8 @@ contract AbstractSortitionPool is SortitionTree, GasStation {
         uint256 flaggedPosition = getFlaggedLeafPosition(operator);
         uint256 leafPosition = flaggedPosition.unsetFlag();
         uint256 leaf = leaves[leafPosition];
-        uint256 createdAt = leaf.creationBlock();
 
-        return block.number > (createdAt + operatorInitBlocks());
+        return isLeafInitialized(leaf);
     }
 
     // Return the weight of the operator in the pool,
@@ -213,6 +212,16 @@ contract AbstractSortitionPool is SortitionTree, GasStation {
             root = _root;
         }
         return selected.array;
+    }
+
+    function isLeafInitialized(uint256 leaf)
+        internal
+        view
+        returns (bool)
+    {
+        uint256 createdAt = leaf.creationBlock();
+
+        return block.number > (createdAt + operatorInitBlocks());
     }
 
     // Return the eligible weight of the operator,

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -151,7 +151,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
         address operator = leaf.operator();
         uint256 leafWeight = leaf.weight();
 
-        if (!isOperatorInitialized(operator)) {
+        if (!isLeafInitialized(leaf)) {
             return Decision.Skip;
         }
 

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -103,10 +103,9 @@ contract SortitionPool is AbstractSortitionPool {
             params := paramsPtr
         }
         address operator = leaf.operator();
-        uint256 createdAt = leaf.creationBlock();
         uint256 leafWeight = leaf.weight();
 
-        if (createdAt + INIT_BLOCKS >= block.number) {
+        if (!isLeafInitialized(leaf)) {
             return Decision.Skip;
         }
 


### PR DESCRIPTION
Querying the leaf position and leaf of an operator to determine eligibility is redundant because we already have that information during group selection. Add `isLeafInitialized` utility function to act directly on the leaf so we don't pay for 2 unnecessary `SLOAD` operations per member.