### PR TITLE
Drop solidity bytes utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   },
   "homepage": "https://github.com/keep-network/sortition-pools#readme",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.4.0",
-    "solidity-bytes-utils": "0.0.7"
+    "@openzeppelin/contracts": "^2.4.0"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.4",


### PR DESCRIPTION
This dependency wasn't used, and pulls in a ton of outdated packages.