### PR TITLE
Minimum stake schedule updates - cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,7 +130,8 @@ address poolAddress = sortitionPoolFactory.createSortitionPool(
   IStaking(keepStakingContract),
   IBonding(keepBondingContract),
   minimumStake,
-  minimumBond
+  minimumBond,
+  poolWeightDivisor
 );
 
 BondedSortitionPool pool = BondedSortitionPool(poolAddress);
@@ -158,8 +159,8 @@ if (!pool.isOperatorUpToDate(operator)) {
 address[] memory members = pool.selectSetGroup(
   groupSize,
   bytes32(groupSelectionSeed),
-  memberBond,
-  minimumStake
+  minimumStake,
+  memberBond
 );
 ----        
 

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -142,9 +142,9 @@ contract BondedSortitionPool is AbstractSortitionPool {
 
         if (eligibleStake < poolParams.minimumStake) { return 0; }
 
-        // Weight = floor(eligibleStake / mimimumStake)
+        // Weight = floor(eligibleStake / poolWeightDivisor)
         // Ethereum uint256 division performs implicit floor
-        // If eligibleStake < minimumStake, return 0 = ineligible.
+        // If eligibleStake < poolWeightDivisor, return 0 = ineligible.
         return (eligibleStake / poolParams.poolWeightDivisor);
     }
 

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -140,11 +140,11 @@ contract BondedSortitionPool is AbstractSortitionPool {
             ownerAddress
         );
 
-        if (eligibleStake < poolParams.minimumStake) {return 0;}
-
         // Weight = floor(eligibleStake / poolWeightDivisor)
+        // but only if eligibleStake >= minimumStake.
         // Ethereum uint256 division performs implicit floor
         // If eligibleStake < poolWeightDivisor, return 0 = ineligible.
+        if (eligibleStake < poolParams.minimumStake) {return 0;}
         return (eligibleStake / poolParams.poolWeightDivisor);
     }
 

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -140,7 +140,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
             ownerAddress
         );
 
-        if (eligibleStake < poolParams.minimumStake) { return 0; }
+        if (eligibleStake < poolParams.minimumStake) {return 0;}
 
         // Weight = floor(eligibleStake / poolWeightDivisor)
         // Ethereum uint256 division performs implicit floor

--- a/contracts/FullyBackedSortitionPoolFactory.sol
+++ b/contracts/FullyBackedSortitionPoolFactory.sol
@@ -12,7 +12,7 @@ contract FullyBackedSortitionPoolFactory {
     /// @param bondingContract Keep Bonding contract reference.
     /// @param minimumStake Minimum stake value making the operator eligible to
     /// join the network.
-    /// @param bondWeightDivisor Constant divisor for the available bond used to 
+    /// @param bondWeightDivisor Constant divisor for the available bond used to
     /// evalate the applicable weight.
     /// @return Address of the new fully-backed sortition pool contract instance.
     function createSortitionPool(

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -95,7 +95,7 @@ contract SortitionPool is AbstractSortitionPool {
             operator,
             params.owner
         );
-        if (operatorStake < params.minimumStake) { return 0; }
+        if (operatorStake < params.minimumStake) {return 0;}
         return operatorStake / params.poolWeightDivisor;
     }
 


### PR DESCRIPTION
We missed two things in #74:

- `BondedSortitionPool` parameters in `README`:
  - `poolWeightDivisor` parameter was missing for `createSortitionPool`function,
  - `memberBond` and `minimumStake` were misplaced in `selectSetGroup`.
- Comment in `BondedSortitionPool.getEligibleWeight`:
  -  We are now dividing the eligible stake by pool weight divisor, not by the minimum stake.

I have additionally cleaned up Solidity linter warnings.

Refs: keep-network/keep-ecdsa#302