### PR TITLE
Bumping up version for 0.3.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8389,6 +8389,21 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "mocha": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
@@ -8404,6 +8419,7 @@
             "growl": "1.10.5",
             "he": "1.1.1",
             "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
             "supports-color": "5.4.0"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "0.2.1-pre.3",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "0.2.1-pre.3",
+  "version": "0.3.0",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
`v0.3.0-rc` will contain:
- Minimum stake schedule support (#74, #78)
- Bump Solidity to 0.5.17 and freeze version (#76)
- Dependency security fix update (#77)