### PR TITLE
Expose totalWeight function

### DIFF
--- a/contracts/SortitionTree.sol
+++ b/contracts/SortitionTree.sol
@@ -74,6 +74,10 @@ contract SortitionTree {
         return (nPossiblyUsedLeaves - nEmptyLeaves);
     }
 
+    function totalWeight() public view returns (uint256) {
+        return root.sumWeight();
+    }
+
     function insertOperator(address operator, uint256 weight) internal {
         require(
             !isOperatorRegistered(operator),
@@ -229,9 +233,5 @@ contract SortitionTree {
 
     function leavesInStack() internal view returns (bool) {
         return emptyLeaves.getSize() > 0;
-    }
-
-    function totalWeight() public view returns (uint256) {
-        return root.sumWeight();
     }
 }

--- a/contracts/SortitionTree.sol
+++ b/contracts/SortitionTree.sol
@@ -231,7 +231,7 @@ contract SortitionTree {
         return emptyLeaves.getSize() > 0;
     }
 
-    function totalWeight() internal view returns (uint256) {
+    function totalWeight() public view returns (uint256) {
         return root.sumWeight();
     }
 }

--- a/contracts/api/IBondedSortitionPool.sol
+++ b/contracts/api/IBondedSortitionPool.sol
@@ -35,4 +35,7 @@ interface IBondedSortitionPool {
     // Update the operator's weight if present and eligible,
     // or remove from the pool if present and ineligible.
     function updateOperatorStatus(address operator) external;
+
+    // Returns the total weight of the pool.
+    function totalWeight() external view returns (uint256);
 }

--- a/contracts/api/ISortitionPool.sol
+++ b/contracts/api/ISortitionPool.sol
@@ -31,4 +31,7 @@ interface ISortitionPool {
     // Update the operator's weight if present and eligible,
     // or remove from the pool if present and ineligible.
     function updateOperatorStatus(address operator) external;
+
+    // Returns the total weight of the pool.
+    function totalWeight() external view returns (uint256);
 }


### PR DESCRIPTION
This pull request makes `totalWeight` function public in order to allow getting the total weight of the sortition pool by external clients.