### PR TITLE
Minimum bondable value for pool and bond value for the current selection

### DIFF
--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -36,7 +36,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
         // Bond required from each operator for the currently pending group
         // selection. If operator does not have at least this unbounded value,
         // it is skipped during the selection.
-        uint256 selectionBond;
+        uint256 requestedBond;
         // The weight divisor in the pool can differ from the minimum stake
         uint256 poolWeightDivisor;
         address owner;
@@ -130,8 +130,8 @@ contract BondedSortitionPool is AbstractSortitionPool {
     ) internal returns (PoolParams memory params) {
         params = poolParams;
 
-        if (params.selectionBond != bondValue) {
-            params.selectionBond = bondValue;
+        if (params.requestedBond != bondValue) {
+            params.requestedBond = bondValue;
         }
 
         if (params.minimumStake != minimumStake) {
@@ -209,7 +209,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
         }
         // If unbonded value is sufficient for the operator to be in the pool
         // but it is not sufficient for the current selection, skip the operator.
-        if (bondableValue < params.selectionBond) {
+        if (bondableValue < params.requestedBond) {
             return Fate(Decision.Skip, 0);
         }
 

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -59,7 +59,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
             _minimumStake,
             _bondingContract,
             _minimumBondableValue,
-            _minimumBondableValue,
+            0,
             _poolWeightDivisor,
             _poolOwner
         );

--- a/test/bondedSortitionPoolTest.js
+++ b/test/bondedSortitionPoolTest.js
@@ -157,30 +157,78 @@ contract('BondedSortitionPool', (accounts) => {
       assert.fail('Expected throw not received')
     })
 
-    it('removes ineligible operators and still works afterwards', async () => {
-      await prepareOperator(accounts[0], 10)
-      await prepareOperator(accounts[1], 11)
-      await prepareOperator(accounts[2], 12)
-      await prepareOperator(accounts[3], 5)
+    it('removes stake-ineligible operators and still works afterwards', async () => {
+      await prepareOperator(accounts[0], 2)
+      await prepareOperator(accounts[1], 2)
+      await prepareOperator(accounts[2], 200)
+      await prepareOperator(accounts[3], 2)
 
       await mineBlocks(11)
 
       await staking.setStake(accounts[2], 1 * minStake)
 
-      try {
-        await pool.selectSetGroup(4, seed, minStake, bond, { from: owner })
-      } catch (error) {
-        assert.include(error.message, 'Not enough operators in pool')
+      // all 4 operators in the pool
+      assert.equal(await pool.operatorsInPool(), 4)
 
-        group = await pool.selectSetGroup.call(3, seed, minStake, bond, { from: owner })
+      // should select group and remove accounts[2]
+      await pool.selectSetGroup(3, seed, 2 * minStake, bond, { from: owner })
 
-        assert.equal(group.length, 3)
-        assert.isFalse(hasDuplicates(group))
+      // should have only 3 operators in the pool now
+      group = await pool.selectSetGroup.call(3, seed, minStake, bond, { from: owner })
 
-        return
-      }
+      assert.equal(group.length, 3)
+      assert.isFalse(hasDuplicates(group))
+      assert.equal(await pool.operatorsInPool(), 3) // accounts[2] removed
+    })
 
-      assert.fail('Expected throw not received')
+    it('removes minimum-bond-ineligible operators and still works afterwards', async () => {
+      await prepareOperator(accounts[0], 2)
+      await prepareOperator(accounts[1], 200)
+      await prepareOperator(accounts[2], 2)
+      await prepareOperator(accounts[3], 2)
+
+      await mineBlocks(11)
+
+      await pool.setMinimumBondableValue(2*bond, { from: owner })
+      await bonding.setBondableValue(accounts[1], 1 * bond)
+
+      // all 4 operators in the pool
+      assert.equal(await pool.operatorsInPool(), 4)
+
+      // should select group and remove accounts[1]
+      await pool.selectSetGroup(3, seed, minStake, 2 * bond, { from: owner })
+
+      // should have only 3 operators in the pool now
+      group = await pool.selectSetGroup.call(3, seed, minStake, bond, { from: owner })
+
+      assert.equal(group.length, 3)
+      assert.isFalse(hasDuplicates(group))
+      assert.equal(await pool.operatorsInPool(), 3) // accounts[1] removed
+    })
+
+    it('skips selection-bond-ineligible operators and still works afterwards', async () => {
+      await prepareOperator(accounts[0], 2)
+      await prepareOperator(accounts[1], 200)
+      await prepareOperator(accounts[2], 2)
+      await prepareOperator(accounts[3], 2)
+
+      await mineBlocks(11)
+
+      await pool.setMinimumBondableValue(1 * bond, { from: owner })
+      await bonding.setBondableValue(accounts[1], 1 * bond)
+
+      // all 4 operators in the pool
+      assert.equal(await pool.operatorsInPool(), 4)
+
+      // should select group and skip accounts[1] (do not remove it!)
+      await pool.selectSetGroup(3, seed, minStake, 2*bond, { from: owner })
+
+      // should still have 4 operators in the pool
+      group = await pool.selectSetGroup.call(3, seed, minStake, bond, { from: owner })
+
+      assert.equal(group.length, 3)
+      assert.isFalse(hasDuplicates(group))
+      assert.equal(await pool.operatorsInPool(), 4)
     })
 
     it('doesn\'t mind operators whose weight has increased', async () => {
@@ -305,6 +353,25 @@ contract('BondedSortitionPool', (accounts) => {
       }
 
       assert.fail('Expected throw not received')
+    })
+  })
+
+  describe('setMinimumBondableValue', async () => {
+    it('can only be called by the owner', async () => {
+      try {
+        await pool.setMinimumBondableValue(1, { from: accounts[0] })
+        assert.fail('Expected throw not received')
+      } catch (error) {
+        assert.include(error.message, 'Only owner may update minimum bond value')
+      }
+    })
+
+    it('updates the minimum bondable value', async () => {
+      await pool.setMinimumBondableValue(1, { from: owner })
+      assert.equal(await pool.getMinimumBondableValue(), 1)
+
+      await pool.setMinimumBondableValue(6, { from: owner })
+      assert.equal(await pool.getMinimumBondableValue(), 6)
     })
   })
 })


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/506

`BondedSortitionPool` was updating the minimum bondable value for each `selectSetGroup` call. The idea was to automatically remove from the pool operators that are no longer able to satisfy application needs about the minimum available bondable value and prevent operators with too low value griefing signer selection.

We now have two minimum bond values: one defining the minimum unbonded value the operator needs to have so that it can join and stay in the pool, and another defining the required bond value for the current selection. If the given operator has enough unbonded value to stay in the pool but it does not have enough unbonded value for the current group selection, it is skipped.

We assume a reasonable minimum bondable value is set on `BondedSortitionPool` creation and it can be later updated by the pool owner (application). We move the responsibility of keeping this value sane to the application. If the application defines allowed lot sizes, just like tBTC, the application may set the minimum bondable value to the minimum lot size and later skip operators that are not eligible to satisfy bond for the current selection instead of removing them from the pool. All operators without at least the minimum unbonded value are removed from the pool during the group selection.