### PR TITLE
Small loop refactor to make Slither happier

### DIFF
--- a/contracts/RNG.sol
+++ b/contracts/RNG.sol
@@ -197,7 +197,7 @@ library RNG {
   {
     uint256 bits = bitsRequired(range);
     bool found = false;
-    uint256 index;
+    uint256 index = 0;
     bytes32 newState = state;
     while (!found) {
       index = truncate(bits, uint256(newState));

--- a/contracts/RNG.sol
+++ b/contracts/RNG.sol
@@ -135,22 +135,22 @@ library RNG {
   /// @return uint The smallest number of bits
   /// that can contain the number `range-1`.
   function bitsRequired(uint256 range) internal pure returns (uint256) {
-    uint256 bits;
     // Start at 19 to be faster for large ranges
-    for (bits = (POSITION_BITS - 1); bits >= 0; bits--) {
-      // Left shift by `bits`,
-      // so we have a 1 in the (bits + 1)th least significant bit
-      // and 0 in other bits.
-      // If this number is equal or greater than `range`,
-      // the range [0, range-1] fits in `bits` bits.
-      //
-      // Because we loop from high bits to low bits,
-      // we find the highest number of bits that doesn't fit the range,
-      // and return that number + 1.
-      if (1 << bits < range) {
-        break;
-      }
+    uint256 bits = POSITION_BITS - 1;
+
+    // Left shift by `bits`,
+    // so we have a 1 in the (bits + 1)th least significant bit
+    // and 0 in other bits.
+    // If this number is equal or greater than `range`,
+    // the range [0, range-1] fits in `bits` bits.
+    //
+    // Because we loop from high bits to low bits,
+    // we find the highest number of bits that doesn't fit the range,
+    // and return that number + 1.
+    while (1 << bits >= range) {
+      bits--;
     }
+
     return bits + 1;
   }
 


### PR DESCRIPTION
Addressing two issues reported by Slither:
```
RNG.bitsRequired(uint256) (RNG.sol#137-155) contains a tautology or contradiction:
        - bits >= 0 (RNG.sol#140)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#tautology-or-contradiction
```
Addressed in d7025e2 by refacoring the loop. The loop should work exactly the same as before except that we avoid the
comparison of `bits >= 0` which is always `true` because `bits` is an `uint`.

```
RNG.getIndex(uint256,bytes32).index (RNG.sol#200) is a local variable never initialized
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-local-variables
```
Addressed in 5588f31 by initializing the `index`. It does not change how the function works and, in
fact, index, when not initialized, is initialized to the default - 0 value. We can however make this code a little cleaner and Slither happier.