### PR TITLE
Bumping up version to 1.1.1 for a new release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
The new release will contain no functionality changes but will re-organize the code based on Linter and Slither suggestions:
- Update linting configuration https://github.com/keep-network/sortition-pools/pull/87
- Small loop refactor to make Slither happier https://github.com/keep-network/sortition-pools/pull/90
- Renamed input parameters to Leaf.make function to avoid shadowing https://github.com/keep-network/sortition-pools/pull/91

See https://github.com/keep-network/sortition-pools/milestone/4?closed=1