### PR TITLE
Use WEIGHT_WIDTH to index full weight range in RNG 

### DIFF
--- a/contracts/RNG.sol
+++ b/contracts/RNG.sol
@@ -12,12 +12,12 @@ library RNG {
   // How many bits a position uses per level of the tree;
   // each branch of the tree contains 2**SLOT_BITS slots.
   uint256 constant SLOT_BITS = 3;
-  uint256 constant LEVELS = 7;
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
   // Derived constants, do not touch
-  uint256 constant POSITION_BITS = LEVELS * SLOT_BITS;
+  uint256 constant SLOT_COUNT = 2**SLOT_BITS;
+  uint256 constant WEIGHT_WIDTH = 256 / SLOT_COUNT;
   ////////////////////////////////////////////////////////////////////////////
 
   struct State {
@@ -127,16 +127,12 @@ library RNG {
   /// @notice Calculate how many bits are required
   /// for an index in the range `[0 .. range-1]`.
   ///
-  /// @dev Our sortition pool can support up to 2^21 virtual stakers,
-  /// therefore we calculate how many bits we need from 1 to 21.
-  ///
   /// @param range The upper bound of the desired range, exclusive.
   ///
   /// @return uint The smallest number of bits
   /// that can contain the number `range-1`.
   function bitsRequired(uint256 range) internal pure returns (uint256) {
-    // Start at 19 to be faster for large ranges
-    uint256 bits = POSITION_BITS - 1;
+    uint256 bits = WEIGHT_WIDTH - 1;
 
     // Left shift by `bits`,
     // so we have a 1 in the (bits + 1)th least significant bit

--- a/test/contracts/BondingContractStub.sol
+++ b/test/contracts/BondingContractStub.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.17;
 
 contract BondingContractStub {
-    mapping(address => uint) unbondedValue;
+    mapping(address => uint) public unbondedValue;
 
     function setBondableValue(address operator, uint256 value) public {
         unbondedValue[operator] = value;

--- a/test/contracts/StakingContractStub.sol
+++ b/test/contracts/StakingContractStub.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.17;
 
 contract StakingContractStub {
-    mapping(address => uint256) stakedTokens;
+    mapping(address => uint256) public stakedTokens;
 
     function eligibleStake(
         address operator,

--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -10,34 +10,33 @@ const DEPLOY = [
   {name: "RNGStub", contract: RNGStub},
 ]
 
-contract("RNG", (accounts) => {
+contract("RNG", () => {
   let rngInstance
 
   before(async () => {
     deployed = await utils.deploySystem(DEPLOY)
     rngInstance = deployed.RNGStub
-
-    indices = [451, 2945, 3017, 3120]
-    weights = [1997, 72, 35, 1984]
-    weightSum = 4088
   })
 
   describe("bitsRequired()", async () => {
     it("Returns the number of bits required", async () => {
-      a = 2 ** 19 - 1
-      b = 2 ** 16
-      c = 2 ** 10 + 1
-      d = 2
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 32 + 1), 32)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 32), 32)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 32 - 1), 32)
 
-      ba = await rngInstance.bitsRequired.call(a)
-      bb = await rngInstance.bitsRequired.call(b)
-      bc = await rngInstance.bitsRequired.call(c)
-      bd = await rngInstance.bitsRequired.call(d)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 31 + 1), 32)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 31), 31)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 31 - 1), 31)
 
-      assert.equal(ba, 19)
-      assert.equal(bb, 16)
-      assert.equal(bc, 11)
-      assert.equal(bd, 1)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 16 + 1), 17)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 16), 16)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 16 - 1), 16)
+
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 2 + 1), 3)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 2), 2)
+      assert.equal(await rngInstance.bitsRequired.call(2 ** 2 - 1), 2)
+
+      assert.equal(await rngInstance.bitsRequired.call(2), 1)
     })
   })
 

--- a/test/workDistributionTest.js
+++ b/test/workDistributionTest.js
@@ -1,0 +1,356 @@
+const Branch = artifacts.require("Branch")
+const Position = artifacts.require("Position")
+const StackLib = artifacts.require("StackLib")
+const Leaf = artifacts.require("Leaf")
+const BondedSortitionPool = artifacts.require(
+  "./contracts/BondedSortitionPool.sol",
+)
+const FullyBackedSortitionPool = artifacts.require(
+  "./contracts/FullyBackedSortitionPool.sol",
+)
+
+const StakingContractStub = artifacts.require("StakingContractStub.sol")
+const BondingContractStub = artifacts.require("BondingContractStub.sol")
+
+const {mineBlocks} = require("./mineBlocks")
+
+const initialSeed =
+  "0xe1df17bc605ccc488fc59e3a69f8101a36094a4d250dd48b5d730c50d6dfdc74"
+const groupSize = 3
+
+const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18)) // 1e18
+const poolWeightDivisor = web3.utils.toBN(10).pow(web3.utils.toBN(18)) // 1e18
+
+// Takes the `operators` array and the array of all `selectionResults` and
+// reduces it into a mapping between the operator and the number of how many
+// times the operator has been selected. If the operator has never been selected
+// and is not in `selectionResults` array, the number of selections is 0.
+function reduceResults(operators, selectionResults) {
+  const accumulator = {}
+  operators.forEach((operator) => (accumulator[operator] = 0))
+
+  return selectionResults.reduce((_, operator) => {
+    accumulator[operator] += 1
+    return accumulator
+  }, accumulator)
+}
+
+contract("BondedSortitionPool", (accounts) => {
+  const owner = accounts[0]
+
+  const minimumStake = web3.utils.toBN("10000").mul(tokenDecimalMultiplier) // 10k KEEP
+  const minimumBondableValue = web3.utils.toBN("20").mul(tokenDecimalMultiplier) // 20 ETH
+
+  let keepBonding
+  let keepStaking
+  let pool
+
+  let operators
+
+  beforeEach(async () => {
+    BondedSortitionPool.link(Branch)
+    BondedSortitionPool.link(Position)
+    BondedSortitionPool.link(StackLib)
+    BondedSortitionPool.link(Leaf)
+    keepStaking = await StakingContractStub.new()
+    keepBonding = await BondingContractStub.new()
+
+    pool = await BondedSortitionPool.new(
+      keepStaking.address,
+      keepBonding.address,
+      minimumStake,
+      minimumBondableValue,
+      poolWeightDivisor,
+      owner,
+    )
+
+    operators = []
+    for (let i = 0; i < 100; i++) {
+      operators.push(web3.eth.accounts.create().address)
+    }
+  })
+
+  describe("selectSetGroup result distribution", async () => {
+    it("is similar between operators with the same stake", async () => {
+      await prepareOperator(operators[0], "1000000", "10000") // 1M KEEP, 10k ETH
+      await prepareOperator(operators[1], "1000000", "500") // 1M KEEP, 500 ETH
+      await prepareOperator(operators[2], "1000000", "100") // 1M KEEP, 100 ETH
+      await prepareOperator(operators[3], "1000000", "100") // 1M KEEP, 50 ETH
+      await prepareOperator(operators[4], "1000000", "100") // 1M KEEP, 40 ETH
+
+      const operatorsInPool = operators.slice(0, 5)
+
+      await mineBlocks(11)
+
+      const allSelections = await runSelections(200)
+      const stats = reduceResults(operatorsInPool, allSelections)
+
+      // We have 5 operators with the same stake and we are running the
+      // selection 200 times. Given that the order does not matter and no
+      // repetitions are allowed, each operator should be selected at least
+      // 100 times.
+      for (const operator of operatorsInPool) {
+        if (stats[operator] == 0) {
+          assert.fail(`operator ${operator} has never been selected`)
+        }
+        if (stats[operator] < 100) {
+          assert.fail(
+            `operator ${operator} should be selected at least 100 times`,
+          )
+        }
+      }
+    })
+
+    it("promotes operators with higher stake", async () => {
+      for (let i = 0; i < 25; i++) {
+        await prepareOperator(operators[i], "1000000", "1000") // 1M KEEP, 1k ETH
+      }
+      for (let i = 25; i < 50; i++) {
+        await prepareOperator(operators[i], "500000", "1000") // 500k KEEP, 1k ETH
+      }
+      for (let i = 50; i < 75; i++) {
+        await prepareOperator(operators[i], "250000", "1000") // 250k KEEP, 1k ETH
+      }
+      for (let i = 75; i < 100; i++) {
+        await prepareOperator(operators[i], "50000", "1000") // 50k KEEP, 1k ETH
+      }
+
+      await mineBlocks(11)
+
+      const allSelections = await runSelections(2500)
+      const stats = reduceResults(operators, allSelections)
+
+      await assertSelectedMoreOftenThan(
+        operators.slice(0, 25),
+        operators.slice(25, 50),
+        stats,
+      )
+      await assertSelectedMoreOftenThan(
+        operators.slice(25, 50),
+        operators.slice(50, 75),
+        stats,
+      )
+      await assertSelectedMoreOftenThan(
+        operators.slice(50, 75),
+        operators.slice(75, 100),
+        stats,
+      )
+    })
+  })
+
+  async function prepareOperator(address, stake, bond) {
+    await keepStaking.setStake(
+      address,
+      web3.utils.toBN(stake).mul(tokenDecimalMultiplier),
+    )
+    await keepBonding.setBondableValue(
+      address,
+      web3.utils.toBN(bond).mul(tokenDecimalMultiplier),
+    )
+    await pool.joinPool(address)
+  }
+
+  // Runs the selectSetGroup `times` times and returns concatenated results
+  // of all selections.
+  async function runSelections(times) {
+    let allSelections = []
+    let seed = initialSeed
+
+    for (let i = 0; i < times; i++) {
+      const group = await pool.selectSetGroup.call(
+        groupSize,
+        seed,
+        minimumStake,
+        minimumBondableValue,
+        {from: owner},
+      )
+      allSelections = allSelections.concat(group)
+      seed = web3.utils.soliditySha3(seed)
+    }
+
+    return allSelections
+  }
+
+  // Asserts whether all operators from `operators` array has been selected more
+  // times than all operators from `thanOperators` array. If not, fails the test.
+  async function assertSelectedMoreOftenThan(operators, thanOperators, stats) {
+    for (operator of operators) {
+      for (anotherOperator of thanOperators) {
+        if (stats[operator] <= stats[anotherOperator]) {
+          const info = await operatorInfo(operator)
+          const anotherInfo = await operatorInfo(anotherOperator)
+
+          assert.fail(
+            `operator ${operator} with stake ${info.stake} KEEP ` +
+              `and unbonded value ${info.bond} ETH ` +
+              `was selected ${stats[operator]} times while ` +
+              `operator ${anotherOperator} with stake ${anotherInfo.stake} KEEP ` +
+              `and unbonded value ${anotherInfo.bond} ETH ` +
+              `was selected ${stats[anotherOperator]} times`,
+          )
+        }
+      }
+    }
+  }
+
+  async function operatorInfo(operator) {
+    const stake = await keepStaking.stakedTokens(operator)
+    const bond = await keepBonding.unbondedValue(operator)
+
+    return {
+      stake: stake.div(tokenDecimalMultiplier),
+      bond: bond.div(tokenDecimalMultiplier),
+    }
+  }
+})
+
+contract("FullyBackedSortitionPool", (accounts) => {
+  const owner = accounts[0]
+
+  const minimumBondableValue = web3.utils.toBN("20").mul(tokenDecimalMultiplier) // 20 ETH
+
+  let keepBonding
+  let pool
+
+  let operators
+
+  beforeEach(async () => {
+    FullyBackedSortitionPool.link(Branch)
+    FullyBackedSortitionPool.link(Position)
+    FullyBackedSortitionPool.link(StackLib)
+    FullyBackedSortitionPool.link(Leaf)
+    keepBonding = await BondingContractStub.new()
+
+    pool = await FullyBackedSortitionPool.new(
+      keepBonding.address,
+      minimumBondableValue,
+      poolWeightDivisor,
+      owner,
+    )
+
+    operators = []
+    for (let i = 0; i < 100; i++) {
+      operators.push(web3.eth.accounts.create().address)
+    }
+  })
+
+  describe("selectSetGroup result distribution", async () => {
+    it("is similar between operators with the same unbonded value", async () => {
+      await prepareOperator(operators[0], "1000000") // 10k ETH
+      await prepareOperator(operators[1], "1000000") // 10k ETH
+      await prepareOperator(operators[2], "1000000") // 10k ETH
+      await prepareOperator(operators[3], "1000000") // 10k ETH
+      await prepareOperator(operators[4], "1000000") // 10k ETH
+
+      const operatorsInPool = operators.slice(0, 5)
+
+      await mineBlocks(11)
+
+      const allSelections = await runSelections(200)
+      const stats = reduceResults(operatorsInPool, allSelections)
+
+      // We have 5 operators with the same stake and we are running the
+      // selection 200 times. Given that the order does not matter and no
+      // repetitions are allowed, each operator should be selected at least
+      // 100 times.
+      for (const operator of operatorsInPool) {
+        if (stats[operator] == 0) {
+          assert.fail(`operator ${operator} has never been selected`)
+        }
+        if (stats[operator] < 100) {
+          assert.fail(
+            `operator ${operator} should be selected at least 100 times`,
+          )
+        }
+      }
+    })
+
+    it("promotes operators with higher unbonded value", async () => {
+      for (let i = 0; i < 25; i++) {
+        await prepareOperator(operators[i], "1000000") // 1M ETH
+      }
+      for (let i = 25; i < 50; i++) {
+        await prepareOperator(operators[i], "500000") // 500k ETH
+      }
+      for (let i = 50; i < 75; i++) {
+        await prepareOperator(operators[i], "250000") // 250k ETH
+      }
+      for (let i = 75; i < 100; i++) {
+        await prepareOperator(operators[i], "50000") // 50k ETH
+      }
+
+      await mineBlocks(11)
+
+      const allSelections = await runSelections(2500)
+      const stats = reduceResults(operators, allSelections)
+
+      await assertSelectedMoreOftenThan(
+        operators.slice(0, 25),
+        operators.slice(25, 50),
+        stats,
+      )
+      await assertSelectedMoreOftenThan(
+        operators.slice(25, 50),
+        operators.slice(50, 75),
+        stats,
+      )
+      await assertSelectedMoreOftenThan(
+        operators.slice(50, 75),
+        operators.slice(75, 100),
+        stats,
+      )
+    })
+  })
+
+  async function prepareOperator(address, bond) {
+    await keepBonding.setBondableValue(
+      address,
+      web3.utils.toBN(bond).mul(tokenDecimalMultiplier),
+    )
+    await pool.joinPool(address)
+  }
+
+  // Runs the selectSetGroup `times` times and returns concatenated results
+  // of all selections.
+  async function runSelections(times) {
+    let allSelections = []
+    let seed = initialSeed
+
+    for (let i = 0; i < times; i++) {
+      const group = await pool.selectSetGroup.call(
+        groupSize,
+        seed,
+        minimumBondableValue,
+        {from: owner},
+      )
+      allSelections = allSelections.concat(group)
+      seed = web3.utils.soliditySha3(seed)
+    }
+
+    return allSelections
+  }
+
+  // Asserts whether all operators from `operators` array has been selected more
+  // times than all operators from `thanOperators` array. If not, fails the test.
+  async function assertSelectedMoreOftenThan(operators, thanOperators, stats) {
+    for (operator of operators) {
+      for (anotherOperator of thanOperators) {
+        if (stats[operator] <= stats[anotherOperator]) {
+          assert.fail(
+            `operator ${operator} with unbonded value ` +
+              `${await operatorUnbondedValue(operator)} ETH ` +
+              `was selected ${stats[operator]} times while ` +
+              `operator ${anotherOperator} with unbonded value ` +
+              `${await operatorUnbondedValue(anotherOperator)} ETH ` +
+              `was selected ${stats[anotherOperator]} times`,
+          )
+        }
+      }
+    }
+  }
+
+  async function operatorUnbondedValue(operator) {
+    const bond = await keepBonding.unbondedValue(operator)
+    return bond.div(tokenDecimalMultiplier)
+  }
+})


### PR DESCRIPTION
The `RNG` was using the `POSITION_BITS` to determine how many total bits can be used in a pool index. This limited the RNG's range to the total number of positions in the pool, rather than the total weight the pool could manage. In previous usage, this was sufficient for total weight as well, but since the system has since moved to handling ETH fully backed pools and denominate KEEP stakes by individual tokens instead of minstakes, the ~2M position limit is no longer sufficient to represent the magnitude of total weights that need to be handled.

In addition to this fix, we are adding two tests for `BondedSortitionPool` and two tests for `FullyBackedSortitionPool` covering the distribution of `selectSetGroup` results.

For `BondedSortitionPool` we are making sure that `selectSetGroup` result distribution:
- is similar between operators with the same stake,
- promotes operators with a higher stake.

For `FullyBackedSortitionPool` we are making sure that `selectSetGroup` result distribution:
- is similar between operators with the same unbonded value,
- promotes operators with a higher unbonded value.

Here are example stats from 2500 selection and 100 operators in a `BondedSortitionPool`, where:
- Operators 0...24 has 1M KEEP staked and 1k ETH unbonded,
- Operators 25...50 has 500k KEEP staked and 1k ETH unbonded,
- Operators 50...75 has 250k KEEP staked and 1k ETH unbonded,
- Operators 75...99 has 50k KEEP staked and 1k ETH unbonded.
```
1M KEEP, 1k ETH:

0xB01cE09e7342f6caFffC2AAC5157681D0aD814cc: 170
0xA91e3C25696AF82a4E471ce4871aC2c5dF38D119: 162
0x0435d56981c3222002B90CCc9807BE7511be91E6: 182
0xf20363e5637551D441ea12F8F63EB81eE4D22438: 161
0x58aA8872D4c8E0A0d28a9444851deebF5CAFa3f4: 139
0x3254785d96F249690df44f6f6F382Ac973526147: 181
0x4A30CACa5f1B28A3d4701217746F54615b086b24: 183
0x3D0738230d4dF91d5BB1213ec167A4420B013e1C: 137
0xBf81E7c9391e7F4B87cC56D7805D2a16c63A1Aeb: 172
0x6255E1f92b267c0838169174f1824119D2915C3E: 154
0x592Af47AFFaeFd01890591A5068D58FA5862FC6f: 168
0x90f3B3AD8f511dF303d1c5282F58E2814D0f990a: 183
0x332DE4fDAC80b73BdeE3C9Ae8D34F62796Cc1d86: 170
0xf043184eceD9E8e69e2b950615c4329Fa79D6380: 166
0x57da3ABc16E2f16eBa9396831454F011b39a5b7E: 160
0xF120413f5970b5159897BA238c64576CAf8cba8a: 178
0x3679D1af742CfD992E6EB2E627A5eaEF1B26F713: 157
0xEC1d413A5D5255A4299548A8e65f6606f55FE986: 180
0xDe04965480c14A69458AFc8f8Db64C3C939C3235: 178
0x6007Ed8B8a963968A0C89dB9a67fa21d4A74D986: 165
0x7039994a27F0458124832121409C7F7332318147: 178
0x02359cC7d894D67889EA9A1160793b58E8d1B9e3: 160
0xA39dD4cc2E2e38Ac5FC85017FC546489DF4c9aAb: 156
0xC5770BB12E8c565Ae8603a02207269b2e5c8397c: 155
0x292305e47f8749a6D80A0B86ca127c05F1A13450: 166

500k KEEP, 1k ETH:

0x0E763edEabf6ab015B834B8050350729fe67EC15: 82
0x1b3AEc26ea6459f30CCc0A1dd788f23A980a1653: 75
0x799358b359dD662B089587f1244f8aE34e9DF95C: 93
0x99DDEaA6Ff20e54578a4321B32dE4c077ec5003D: 81
0xd6Ce108589a5302B00fFB4dbC408D52336d736Ae: 80
0x9ACcd17012E3D53Ab28CAb68753507D53307e85f: 82
0x2E768DAD7f88E1589d916f07Fdd8C092e7a6426d: 94
0x1B4FDA788eBF6aB04092D6E7DfBbd0C6cB9701D1: 78
0x2f731D1FddC4C11A9505CaC2A5611BEd37d39994: 88
0x90829ad9b0Eb2BFfA76da5C97122D514c678Cc02: 89
0x30a0fE5920d3f4b89022005F7966B06C67e954D8: 85
0xd342563c3e73e82b5eE0c9b713288B4D29d36917: 81
0xBBFF0E131D2Bab7321fCb2FD2265555448d4a4E0: 80
0x609A852774058C1f4B5736237F1b47f66a9F5341: 89
0x5798fD472DeA340FF5eeDa46d8934b2c55bBdA74: 104
0x7194Ec1cb73eb2005c0e4cB5dA5F94E76087C1Fd: 76
0x3fC4B7424B414297223DC4e08E474c913F0Ec20b: 84
0xFFf53e282B1b4f21Bb478330DdC648b7cA200F25: 112
0xd331a1b2D9799b8aA282Af7A82AE5A9b5f63f3A4: 92
0x786A9D0488d8D3a005D9e0582E3a634fCfc57dA6: 93
0xD936A6E3A5D7F76dA9C408df8f203A54fa34FC0D: 75
0xb91E8DcA5c6422833B5670F55C322A4A2031D6C2: 66
0x1dEF54458Fe315C581a91cad6C1a1A9B5BeC2df9: 77
0xBa5820AA8A925D749dDee41be06EfE35e1108711: 82
0x9f6F582f2bE24f826aC2f9EE6dC1d4413E9C584B: 61

 250k KEEP, 1k ETH:

0x35Ca9F57b860c33176cA9a71E0E37c3aa54D8a4c: 53
0x1f79d3C0C23D036C2C1a15bfEEfea7beD2F4963e: 50
0xABE7aFdda74466F47F694352aec29Fe355A11aa1: 35
0x528f686B4f62666D60a6fbBdBB853a84e39a6CC5: 33
0x0e445776b2f5E1704b78B099D1A6588B474f6f20: 42
0x9d63F628DDb394d9B6bf0790759c807D96ff5D21: 39
0xa7634a9141b0c289A63D1951d469ca864AEd1116: 49
0xD51A800A044B61229b44e3e3b5B60938C2b2176f: 32
0x6965e97CAE7068f33bE69052F729359528f844C4: 35
0xB3eDd9bD1b30e29f12f54D91C1Ef0787918cC252: 52
0x7057f2381A50a14D837d5750518df6f13b33a2b6: 30
0xe2bD80f1291cB4459eC47FEC4971e5651dAc2990: 49
0x22198c29e29a58eb3E95C7B8242FCe6C45D3dD79: 39
0x26E6EF424849ea1789c2cd2f8D05e1C9d0910426: 41
0xcbB1F5532B67bfF8fb38cFA46f18D97db3D9057E: 36
0x5Bc9f95a02890fD76bE6f201004fbba7D626c3FD: 42
0x640d6DE630CfAF61B2F5D617Bd5eb9e3968Fae9e: 41
0xB6e9AF247640A7F0E70d2900984b082e37f6856f: 43
0xAEE2A6Ce00B72c99f906D2c29625B558d45A54DB: 48
0x4bFD429b64bfDd2D6CdB10019e10b73c23A1ebDb: 35
0xF4AD9A8912abc433837e1D1E819D81848c49B249: 47
0xFF6b8c8400F2A8a3c904B7fb77A48c08CA6395ee: 40
0xE7cb2B37035E0406165E7A7333E5804eD4C46585: 44
0xdfD72DbA891fb761885A0A8B6d3E8c72592dD99A: 36
0xA31A8E0118528CAa996F52B453761b9790896533: 45

50k KEEP, 1k ETH:

0x6Bcb502a987E22c7D715728ab350438DBC44149d: 5
0xb39241b5f3Aa4ea8edbddDCe87EB16294E1B56b9: 11
0xA225E214ba1d4e5aCEFD3013208a0Ed9d9fB6D6e: 11
0xA6a7fcA7E2003794A87Ce4F3F8cF6041e4A297ca: 7
0x01750939be7eE311F74b7AD46A97DDD590fc18cf: 12
0x67298AD2423B34Dfa27D25896C4529b3e4cE99Fb: 9
0xA7357322CAD4BA6FE731615d2193e56Bb1D582CA: 9
0xd7f8F665b09Ec4f79d131118D699160687D8e301: 7
0x967AB153936A2cD4b1d163A464F6252A4A39957F: 7
0xCaC291014C4A0b4AEB7155885F2323832332105b: 6
0xc972Effa6b5433D7104b77C5631Dcb01bB4F34D9: 11
0xe95d98D6A7bf530dBa9A2e027dC60f64EF660A02: 10
0x911b77214D5799A3a64Fcbd548a883db2BE6Cc64: 9
0xd2aBd2e5B5e8E4a27d70231D6ebc6Fbae9bfEDf4: 13
0x1CDA6e460bb6f9e1AE4D54A8ef51e0cBb43A9838: 7
0xfe524Cb9B4DF08dc92183Fc836407987d204F657: 6
0xBbdaBbAC75dCb383F05F41BF1a89421017fc09EA: 10
0x7f6e98F81D7E446236F66cBef3F3E312eF791b3c: 11
0x2281602173e90C0641359D4Cf437bB5F75d5fA58: 5
0xE9BA4C18f08895d51A914D217e6ee8abe54c744D: 2
0x9429a7FcfFBcF4096ff65B0a2eED001128197e0E: 8
0x4C1366bC1455Bf0DC079747e802619de4A82547c: 6
0xF8Cb59AcCEE4F39F39E254B96a7057512C3b191F: 5
0x2Da410Ea04cc16297d4De2058350653481ed224b: 9
0xD9afc6d000ea9e5655a30b034b06f15B36A8F816: 8
```