### PR TITLE
Bumping up version to 1.1.2 for a new release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
The new release will contain two changes:
- Use WEIGHT_WIDTH to index full weight range in RNG  #94 
- Babe the Blue Ox: Add rudimentary buidler setup #93 

See https://github.com/keep-network/sortition-pools/milestone/5?closed=1