### PR TITLE
Ban operator in FullyBackedSortitionPool

### DIFF
--- a/contracts/FullyBackedSortitionPool.sol
+++ b/contracts/FullyBackedSortitionPool.sol
@@ -56,6 +56,10 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
 
   PoolParams poolParams;
 
+  // Banned operator addresses. Banned operators are removed from the pool; they
+  // won't be selected to groups and won't be able to join the pool.
+  mapping(address => bool) public bannedOperators;
+
   constructor(
     IFullyBackedBonding _bondingContract,
     uint256 _initialMinimumBondableValue,
@@ -119,6 +123,18 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
     return poolParams.minimumBondableValue;
   }
 
+  /// @notice Bans an operator in the pool. The operator is added to banned
+  /// operators list. If the operator is already registered in the pool it gets
+  /// removed. Only onwer of the pool can call this function.
+  /// @param operator An operator address.
+  function ban(address operator) public onlyOwner() {
+    bannedOperators[operator] = true;
+
+    if (isOperatorRegistered(operator)) {
+      removeOperator(operator);
+    }
+  }
+
   function initializeSelectionParams(uint256 bondValue)
     internal
     returns (PoolParams memory params)
@@ -136,6 +152,11 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
   // which may differ from the weight in the pool.
   // Return 0 if ineligible.
   function getEligibleWeight(address operator) internal view returns (uint256) {
+    // Check if the operator has been banned.
+    if (bannedOperators[operator]) {
+      return 0;
+    }
+
     address ownerAddress = poolParams.owner;
     // Get the amount of bondable value available for this pool.
     // We only care that this covers one single bond
@@ -233,5 +254,10 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
     // Not sure if we want to do this exact thing,
     // but reasonable to begin with.
     return Fate(Decision.UpdateSelect, postWeight);
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == poolParams.owner, "Caller is not the owner");
+    _;
   }
 }

--- a/contracts/FullyBackedSortitionPool.sol
+++ b/contracts/FullyBackedSortitionPool.sol
@@ -91,9 +91,9 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
     uint256 groupSize,
     bytes32 seed,
     uint256 bondValue
-  ) public returns (address[] memory) {
+  ) public onlyOwner() returns (address[] memory) {
     PoolParams memory params = initializeSelectionParams(bondValue);
-    require(msg.sender == params.owner, "Only owner may select groups");
+
     uint256 paramsPtr;
     // solium-disable-next-line security/no-inline-assembly
     assembly {

--- a/test/fullyBackedSortitionPoolTest.js
+++ b/test/fullyBackedSortitionPoolTest.js
@@ -173,7 +173,7 @@ contract("FullyBackedSortitionPool", (accounts) => {
 
       await expectRevert(
         pool.selectSetGroup(3, seed, minimumBondableValue, {from: alice}),
-        "Only owner may select groups",
+        "Caller is not the owner",
       )
     })
 

--- a/test/fullyBackedSortitionPoolTest.js
+++ b/test/fullyBackedSortitionPoolTest.js
@@ -173,7 +173,7 @@ contract("FullyBackedSortitionPool", (accounts) => {
 
       await expectRevert(
         pool.selectSetGroup(3, seed, minimumBondableValue, {from: alice}),
-        "Caller is not the owner",
+        "Only owner may select groups",
       )
     })
 
@@ -464,10 +464,7 @@ contract("FullyBackedSortitionPool", (accounts) => {
     })
 
     it("reverts when called by non-owner", async () => {
-      await expectRevert(
-        pool.ban(alice, {from: owner}),
-        "Caller is not the owner",
-      )
+      await expectRevert(pool.ban(alice), "Caller is not the owner")
     })
   })
 })

--- a/test/fullyBackedSortitionPoolTest.js
+++ b/test/fullyBackedSortitionPoolTest.js
@@ -173,7 +173,7 @@ contract("FullyBackedSortitionPool", (accounts) => {
 
       await expectRevert(
         pool.selectSetGroup(3, seed, minimumBondableValue, {from: alice}),
-        "Only owner may select groups",
+        "Caller is not the owner",
       )
     })
 
@@ -438,6 +438,15 @@ contract("FullyBackedSortitionPool", (accounts) => {
     it("adds operator to banned operators", async () => {
       expect(await pool.bannedOperators(alice)).to.be.false
 
+      await pool.ban(alice, {from: owner})
+
+      expect(await pool.bannedOperators(alice)).to.be.true
+    })
+
+    it("does not revert when called multiple times", async () => {
+      expect(await pool.bannedOperators(alice)).to.be.false
+
+      await pool.ban(alice, {from: owner})
       await pool.ban(alice, {from: owner})
 
       expect(await pool.bannedOperators(alice)).to.be.true


### PR DESCRIPTION
Added functionality of operators banning in FullyBackedSortitionPool contract.

A pool owner can call a function to ban an operator. Once an operator gets banned it is removed from the pool. The operator won't get selected to new groups.

An operator can be banned even if it has never been registered or is not currently registered in the pool.

A banned operator cannot join a pool.

Depends on https://github.com/keep-network/sortition-pools/pull/89
Depends on https://github.com/keep-network/sortition-pools/pull/97
Refs keep-network/keep-ecdsa#483