### PR TITLE
Let owner unregister operator from Fully Backed Sortition Pool

### DIFF
--- a/contracts/FullyBackedSortitionPool.sol
+++ b/contracts/FullyBackedSortitionPool.sol
@@ -130,6 +130,13 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
   function ban(address operator) public onlyOwner() {
     bannedOperators[operator] = true;
 
+    unregister(operator);
+  }
+
+  /// @notice Removes an operator from the pool. Only onwer of the pool can call
+  /// this function.
+  /// @param operator An operator address.
+  function unregister(address operator) public onlyOwner() {
     if (isOperatorRegistered(operator)) {
       removeOperator(operator);
     }

--- a/test/fullyBackedSortitionPoolTest.js
+++ b/test/fullyBackedSortitionPoolTest.js
@@ -476,4 +476,46 @@ contract("FullyBackedSortitionPool", (accounts) => {
       await expectRevert(pool.ban(alice), "Caller is not the owner")
     })
   })
+
+  describe("unregister", async () => {
+    it("does not revert when operator is not registered", async () => {
+      expect(await pool.isOperatorRegistered(alice)).to.be.false
+
+      await pool.unregister(alice, {from: owner})
+    })
+
+    it("removes operator from the pool", async () => {
+      await bonding.setBondableValue(alice, minimumBondableValue)
+      await bonding.setInitialized(alice, true)
+      await pool.joinPool(alice)
+
+      expect(await pool.isOperatorRegistered(alice)).to.be.true
+
+      await pool.unregister(alice, {from: owner})
+
+      expect(await pool.isOperatorRegistered(alice)).to.be.false
+      expect(await pool.isOperatorInPool(alice)).to.be.false
+      expect(await pool.getPoolWeight(alice)).to.eq.BN(0)
+    })
+
+    it("operator can re-join the pool after removal", async () => {
+      await bonding.setBondableValue(alice, minimumBondableValue)
+      await bonding.setInitialized(alice, true)
+      await pool.joinPool(alice)
+
+      expect(await pool.isOperatorRegistered(alice)).to.be.true
+
+      await pool.unregister(alice, {from: owner})
+
+      expect(await pool.isOperatorRegistered(alice)).to.be.false
+
+      await pool.joinPool(alice)
+
+      expect(await pool.isOperatorRegistered(alice)).to.be.true
+    })
+
+    it("reverts when called by non-owner", async () => {
+      await expectRevert(pool.unregister(alice), "Caller is not the owner")
+    })
+  })
 })


### PR DESCRIPTION
Let owner of a fully backed sortition pool to unregister an operator.
This function can be helpful to remove operators that are inactive.
After being removed operator can re-join the pool right away.