### PR TITLE
Updated GitHub action for NPM package publication

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,13 +2,13 @@ name: NPM
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "contracts/**"
-      - "migrations/scripts/**"
-      - "package.json"
-      - "package-lock.json"
+    # branches:
+    #   - master
+    # paths:
+    #   - "contracts/**"
+    #   - "migrations/scripts/**"
+    #   - "package.json"
+    #   - "package-lock.json"
 
 jobs:
   publish-contracts:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -37,6 +37,14 @@ jobs:
           version=$(jq --raw-output .version package.json)
           preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
 
+          # Check resolved `preid`. Currently only `pre` value is supported,
+          # other types of releases are not handled by this job.
+          if [ "$preid" != pre ]; then
+            echo "Unsupported preid. Resolved info:"
+            echo "$name@$version ; preid $preid"
+            exit 1
+          fi
+
           # Find the latest published package version matching this preid.
           # Note that in jq, we wrap the result in an array and then flatten;
           # this is because npm show json contains a single string if there

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -12,35 +12,56 @@ on:
 
 jobs:
   publish-contracts:
-    # Don't run the job if commit message starts with `[CI]`.
-    if: startsWith(github.event.commits[0].message, '[CI]') == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "11.x"
-          registry-url: "https://npm.pkg.github.com"
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@keep-network"
+      - name: Cache node modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Bump up version
+        run: |
+          name=$(jq --raw-output .name package.json)
+          version=$(jq --raw-output .version package.json)
+          preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+          # Find the latest published package version matching this preid.
+          # Note that in jq, we wrap the result in an array and then flatten;
+          # this is because npm show json contains a single string if there
+          # is only one matching version, or an array if there are multiple,
+          # and we want to look at an array always.
+          latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
+          latest_version=${latest_version:-$version}
+          if [ -z $latest_version ]; then
+            echo "Latest version calculation failed. Resolved info:"
+            echo "$name@$version ; preid $preid"
+            exit 1
+          fi
+
+          # Update package.json with the latest published package version matching this
+          # preid to prepare for bumping.
+          echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+          # Bump without doing any git work. Versioning is a build-time action for us.
+          # Consider including commit id? Would be +<commit id>.
+          npm version prerelease --preid=$preid --no-git-tag-version
+
+          # Fix resolved dependency versions.
+          npm update
+
       - name: Publish package
-        run: npm publish
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Bump version
-        run: |
-          PACKAGE_VERSION=$(npm version --no-git-tag-version prerelease --preid=pre)
-          echo "::set-env name=PACKAGE_VERSION::$PACKAGE_VERSION"
-      - name: Setup git
-        run: |
-          git remote set-url origin https://${{ secrets.CI_GITHUB_TOKEN }}@github.com/keep-network/sortition-pools.git
-          git config user.email "thesis-heimdall@users.noreply.github.com"
-          git config user.name "Heimdall"
-      - name: Commit
-        env:
-          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
-        run: |
-          GITHUB_REF=${{ github.ref }}
-          BRANCH=${GITHUB_REF#refs/heads/} # strip branch name from github reference, branch name is prefixed with `refs/heads`
-          git checkout $BRANCH
-          git add package.json package-lock.json
-          git commit -m "[CI] Auto-bump pre-release package to $PACKAGE_VERSION"
-          git push origin $BRANCH
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,13 +2,13 @@ name: NPM
 
 on:
   push:
-    # branches:
-    #   - master
-    # paths:
-    #   - "contracts/**"
-    #   - "migrations/scripts/**"
-    #   - "package.json"
-    #   - "package-lock.json"
+    branches:
+      - master
+    paths:
+      - "contracts/**"
+      - "migrations/scripts/**"
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   publish-contracts:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -66,9 +66,6 @@ jobs:
           # Consider including commit id? Would be +<commit id>.
           npm version prerelease --preid=$preid --no-git-tag-version
 
-          # Fix resolved dependency versions.
-          npm update
-
       - name: Publish package
         run: npm publish --access public
         env:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,14 +14,14 @@ jobs:
   publish-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@keep-network"
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           cache-name: cache-solidity-node-modules
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@keep-network:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.2",
+  "version": "1.1.3-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "contracts/**/*.sol",
     "migrations/scripts"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "scripts": {
     "ganache": "echo 'GANACHE IS NO LONGER USED; use buidler-vm script instead'",
     "buidler-vm": "buidler node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.1.2",
+  "version": "1.1.3-pre.0",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
Here we update script for publishing NPM package in GitHub Actions job.

For `master` branch we want to publish `pre` package on each `master`
merge. But there is no sense in doing so if nothing has changed in the
solidity contracts. Circle CI doesn't allow us to filter on changed
content to run a job, that's why we use GitHub Actions. We will publish
new `pre` package to NPM registry on master merge only if solidity
contracts have changed.

Publishing to NPM registry requires a `NPM_TOKEN` token to be configured
in GH project's secrets variables.

Refs: keep-network/keep-ecdsa#659