### PR TITLE
Add and benchmark `SortitionPool.selectSetGroup`

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -61,6 +61,30 @@ contract SortitionPool is AbstractSortitionPool {
     return generalizedSelectGroup(groupSize, seed, paramsPtr, false);
   }
 
+  /// @notice Selects a new group of operators of the provided size based on
+  /// the provided pseudo-random seed.
+  /// All operators in the group are unique.
+  /// If there are not enough operators in a pool to form a group
+  /// or not enough operators are eligible for work selection,
+  /// the function fails.
+  /// @param groupSize Size of the requested group
+  /// @param seed Pseudo-random number used to select operators to group
+  /// @return selected Members of the selected group
+  function selectSetGroup(
+    uint256 groupSize,
+    bytes32 seed,
+    uint256 minimumStake
+  ) public returns (address[] memory) {
+    PoolParams memory params = initializeSelectionParams(minimumStake);
+    require(msg.sender == params.owner, "Only owner may select groups");
+    uint256 paramsPtr;
+    // solium-disable-next-line security/no-inline-assembly
+    assembly {
+      paramsPtr := params
+    }
+    return generalizedSelectGroup(groupSize, seed, paramsPtr, true);
+  }
+
   function initializeSelectionParams(uint256 currentMinimumStake)
     internal
     returns (PoolParams memory params)

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -191,4 +191,32 @@ contract("SortitionPool", (accounts) => {
       assert.equal(group.length, 100)
     })
   })
+
+  describe("selectSetGroup", async () => {
+    it("works", async () => {
+      const nOperators = 1000
+      const nSelected = 100
+      for (i = 1010; i < 1010 + nOperators; i++) {
+        const address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + i.toString()
+        await staking.setStake(address, minStake * i)
+        await pool.joinPool(address)
+      }
+
+      await mineBlocks(11)
+
+      const group = await pool.selectSetGroup.call(nSelected, seed, minStake, {
+        from: owner,
+      })
+      const tx = await pool.selectSetGroup(nSelected, seed, minStake, {
+        from: owner,
+      })
+      assert.equal(group.length, nSelected)
+      const gasUsed = tx.receipt.gasUsed
+      console.log("Number of operators: " + nOperators)
+      console.log("Number selected: " + nSelected)
+      console.log("Total gas: " + gasUsed)
+      console.log("Gas per member: " + gasUsed / nSelected)
+      assert.equal(gasUsed < 8000000, true)
+    })
+  })
 })


### PR DESCRIPTION
When selecting large groups from large numbers of operators, selection costs approximately 32,000 gas per operator.