### PR TITLE
Use GitHub Action to bump npm package version

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,13 +2,13 @@ name: NPM
 
 on:
   push:
-    # branches:
-    #   - master
-    # paths:
-    #   - "contracts/**"
-    #   - "migrations/scripts/**"
-    #   - "package.json"
-    #   - "package-lock.json"
+    branches:
+      - master
+    paths:
+      - "contracts/**"
+      - "migrations/scripts/**"
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   publish-contracts:
@@ -32,10 +32,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - uses: keep-network/npm-version-bump@v1
-      # TODO: Just for testing
-      - name: Print package.json content
-        run: cat package.json
-      # - name: Publish package
-      #   run: npm publish --access public
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,7 +31,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - uses: keep-network/npm-version-bump@v1
+      - name: Bump up package version
+        uses: keep-network/npm-version-bump@v1
       - name: Publish package
         run: npm publish --access public
         env:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,13 +2,13 @@ name: NPM
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "contracts/**"
-      - "migrations/scripts/**"
-      - "package.json"
-      - "package-lock.json"
+    # branches:
+    #   - master
+    # paths:
+    #   - "contracts/**"
+    #   - "migrations/scripts/**"
+    #   - "package.json"
+    #   - "package-lock.json"
 
 jobs:
   publish-contracts:
@@ -32,7 +32,10 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - uses: keep-network/npm-version-bump@v1
-      - name: Publish package
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # TODO: Just for testing
+      - name: Print package.json content
+        run: cat package.json
+      # - name: Publish package
+      #   run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,41 +31,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Bump up version
-        run: |
-          name=$(jq --raw-output .name package.json)
-          version=$(jq --raw-output .version package.json)
-          preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
-
-          # Check resolved `preid`. Currently only `pre` value is supported,
-          # other types of releases are not handled by this job.
-          if [ "$preid" != pre ]; then
-            echo "Unsupported preid. Resolved info:"
-            echo "$name@$version ; preid $preid"
-            exit 1
-          fi
-
-          # Find the latest published package version matching this preid.
-          # Note that in jq, we wrap the result in an array and then flatten;
-          # this is because npm show json contains a single string if there
-          # is only one matching version, or an array if there are multiple,
-          # and we want to look at an array always.
-          latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
-          latest_version=${latest_version:-$version}
-          if [ -z $latest_version ]; then
-            echo "Latest version calculation failed. Resolved info:"
-            echo "$name@$version ; preid $preid"
-            exit 1
-          fi
-
-          # Update package.json with the latest published package version matching this
-          # preid to prepare for bumping.
-          echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
-
-          # Bump without doing any git work. Versioning is a build-time action for us.
-          # Consider including commit id? Would be +<commit id>.
-          npm version prerelease --preid=$preid --no-git-tag-version
-
+      - uses: keep-network/npm-version-bump@v1
       - name: Publish package
         run: npm publish --access public
         env:


### PR DESCRIPTION
We pulled a common script bumping the NPM package version to a GitHub Action that can be reused in our projects ([keep-network/npm-version-bump](https://github.com/keep-network/npm-version-bump/blob/main/action.yml)).  Here we're switching to use this action.

The workflow has been executed successfully in the following run: https://github.com/keep-network/sortition-pools/pull/106/checks?check_run_id=1865099712