### PR TITLE
Unify `NPM` workflow with `NPM` workflows in other projects

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -11,15 +11,19 @@ on:
       - "package-lock.json"
 
 jobs:
-  publish-contracts:
+  npm-publish-contracts:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          scope: "@keep-network"
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -31,42 +35,17 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Bump up version
-        run: |
-          name=$(jq --raw-output .name package.json)
-          version=$(jq --raw-output .version package.json)
-          preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
 
-          # Check resolved `preid`. Currently only `pre` value is supported,
-          # other types of releases are not handled by this job.
-          if [ "$preid" != pre ]; then
-            echo "Unsupported preid. Resolved info:"
-            echo "$name@$version ; preid $preid"
-            exit 1
-          fi
-
-          # Find the latest published package version matching this preid.
-          # Note that in jq, we wrap the result in an array and then flatten;
-          # this is because npm show json contains a single string if there
-          # is only one matching version, or an array if there are multiple,
-          # and we want to look at an array always.
-          latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
-          latest_version=${latest_version:-$version}
-          if [ -z $latest_version ]; then
-            echo "Latest version calculation failed. Resolved info:"
-            echo "$name@$version ; preid $preid"
-            exit 1
-          fi
-
-          # Update package.json with the latest published package version matching this
-          # preid to prepare for bumping.
-          echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
-
-          # Bump without doing any git work. Versioning is a build-time action for us.
-          # Consider including commit id? Would be +<commit id>.
-          npm version prerelease --preid=$preid --no-git-tag-version
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          work-dir: ./solidity
+          environment: dev
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
 
       - name: Publish package
-        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
Workflow has been modified to look similiar to `NPM` workflows in
`keep-core` and `keep-ecdsa`. The main change is switching to use of
`npm-version-bump` action.