### PR TITLE
Use `-dev` suffix in the versioning of the `sortition-pools`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.2.0-pre.0",
+  "version": "1.2.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.2.0-pre.0",
+  "version": "1.2.0-dev",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
`-dev` suffix will be used for the versioning of the `sortition-pools`
package built with the purpose of being used on development environment.
Packages with the `-dev`-suffix will be pushed to the NPM registry by
the `NPM` GH Actions workflow.
Note that packages ment for the test environment (Ropsten) will be
versioned independently, based on the suffix provided during manual
triggering of the `Main` workflow in `ci` project.