### PR TITLE
Update custom actions paths after moving actions to `ci`

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: keep-network/ci/actions/npm-version-bump@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           environment: dev
           branch: ${{ github.ref }}


### PR DESCRIPTION
We've moved custom actions used in the Keep/tBTC Continuous Integration
from separate repositories to `ci` repository (under `actions` folder).
We now need to update all the actions' invokations.

Note that temporarily we call the actions on the feature branch - this
is only for testing purposes and will be changed to `@v1` once tested.

Refs:
https://github.com/keep-network/ci/pull/11
https://github.com/keep-network/keep-core/pull/2545
https://github.com/keep-network/keep-ecdsa/pull/868
https://github.com/keep-network/tbtc/pull/816
https://github.com/keep-network/tbtc-dapp/pull/400
https://github.com/keep-network/tbtc.js/pull/128
https://github.com/keep-network/keep-common/pull/80
https://github.com/keep-network/coverage-pools/pull/167

TODO:
- [ ] test deployment flow on the feature branch
- [ ] point to `@v1` in lines invoking actions (same change required in other repos)