### PR TITLE
Add unique operator ID numbers and return them in group selection

### DIFF
--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -169,6 +169,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
 
   function decideFate(
     uint256 leaf,
+    uint256 leafWeight,
     DynamicArray.AddressArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
@@ -178,7 +179,6 @@ contract BondedSortitionPool is AbstractSortitionPool {
       params := paramsPtr
     }
     address operator = leaf.operator();
-    uint256 leafWeight = leaf.weight();
 
     if (!isLeafInitialized(leaf)) {
       return Fate(Decision.Skip, 0);

--- a/contracts/BondedSortitionPool.sol
+++ b/contracts/BondedSortitionPool.sol
@@ -91,7 +91,14 @@ contract BondedSortitionPool is AbstractSortitionPool {
     assembly {
       paramsPtr := params
     }
-    return generalizedSelectGroup(groupSize, seed, paramsPtr, true);
+    uint256[] memory selected = generalizedSelectGroup(
+        groupSize, seed, paramsPtr, true
+    );
+    address[] memory selectedAddresses = new address[](groupSize);
+    for (uint256 i = 0; i < selected.length; i++) {
+        selectedAddresses[i] = selected[i].operator();
+    }
+    return selectedAddresses;
   }
 
   /// @notice Sets the minimum bondable value required from the operator
@@ -170,7 +177,7 @@ contract BondedSortitionPool is AbstractSortitionPool {
   function decideFate(
     uint256 leaf,
     uint256 leafWeight,
-    DynamicArray.AddressArray memory, // `selected`, for future use
+    DynamicArray.UintArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
     PoolParams memory params;

--- a/contracts/FullyBackedSortitionPool.sol
+++ b/contracts/FullyBackedSortitionPool.sol
@@ -190,6 +190,7 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
 
   function decideFate(
     uint256 leaf,
+    uint256 leafWeight,
     DynamicArray.AddressArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
@@ -199,7 +200,6 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
       params := paramsPtr
     }
     address operator = leaf.operator();
-    uint256 leafWeight = leaf.weight();
 
     if (!isLeafInitialized(leaf)) {
       return Fate(Decision.Skip, 0);

--- a/contracts/FullyBackedSortitionPool.sol
+++ b/contracts/FullyBackedSortitionPool.sol
@@ -99,7 +99,14 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
     assembly {
       paramsPtr := params
     }
-    return generalizedSelectGroup(groupSize, seed, paramsPtr, true);
+    uint256[] memory selected = generalizedSelectGroup(
+        groupSize, seed, paramsPtr, true
+    );
+    address[] memory selectedAddresses = new address[](groupSize);
+    for (uint256 i = 0; i < selected.length; i++) {
+        selectedAddresses[i] = selected[i].operator();
+    }
+    return selectedAddresses;
   }
 
   /// @notice Sets the minimum bondable value required from the operator
@@ -191,7 +198,7 @@ contract FullyBackedSortitionPool is AbstractSortitionPool {
   function decideFate(
     uint256 leaf,
     uint256 leafWeight,
-    DynamicArray.AddressArray memory, // `selected`, for future use
+    DynamicArray.UintArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
     PoolParams memory params;

--- a/contracts/Interval.sol
+++ b/contracts/Interval.sol
@@ -60,6 +60,10 @@ library Interval {
     return (op & (~(START_INDEX_MAX << WEIGHT_WIDTH))) | shiftedIndex;
   }
 
+  function weight(uint256 a) internal pure returns (uint256) {
+    return (a & WEIGHT_MAX);
+  }
+
   function insert(DynamicArray.UintArray memory intervals, uint256 interval)
     internal
     pure
@@ -91,7 +95,7 @@ library Interval {
       if (mappedIndex >= index(interval)) {
         // Add the weight of this previous leaf to the index,
         // ensuring that we skip the leaf.
-        mappedIndex += Leaf.weight(interval);
+        mappedIndex += weight(interval);
       } else {
         break;
       }

--- a/contracts/Leaf.sol
+++ b/contracts/Leaf.sol
@@ -56,6 +56,7 @@ library Leaf {
   function weight(uint256 leaf) internal pure returns (uint256) {
     // Weight is stored in the 32 least significant bits.
     // Bitwise AND ensures that we only get the contents of those bits.
+    require(false, "this should not be called");
     return (leaf & WEIGHT_MAX);
   }
 

--- a/contracts/Leaf.sol
+++ b/contracts/Leaf.sol
@@ -15,10 +15,10 @@ library Leaf {
   uint256 constant SLOT_WIDTH = 256 / SLOT_COUNT;
   uint256 constant SLOT_MAX = (2**SLOT_WIDTH) - 1;
 
-  uint256 constant WEIGHT_WIDTH = SLOT_WIDTH;
-  uint256 constant WEIGHT_MAX = SLOT_MAX;
+  uint256 constant ID_WIDTH = SLOT_WIDTH;
+  uint256 constant ID_MAX = SLOT_MAX;
 
-  uint256 constant BLOCKHEIGHT_WIDTH = 96 - WEIGHT_WIDTH;
+  uint256 constant BLOCKHEIGHT_WIDTH = 96 - ID_WIDTH;
   uint256 constant BLOCKHEIGHT_MAX = (2**BLOCKHEIGHT_WIDTH) - 1;
 
   ////////////////////////////////////////////////////////////////////////////
@@ -26,20 +26,20 @@ library Leaf {
   function make(
     address _operator,
     uint256 _creationBlock,
-    uint256 _weight
+    uint256 _id
   ) internal pure returns (uint256) {
     // Converting a bytesX type into a larger type
     // adds zero bytes on the right.
     uint256 op = uint256(bytes32(bytes20(_operator)));
-    // Bitwise AND the weight to erase
+    // Bitwise AND the id to erase
     // all but the 32 least significant bits
-    uint256 wt = _weight & WEIGHT_MAX;
+    uint256 id = _id & ID_MAX;
     // Erase all but the 64 least significant bits,
-    // then shift left by 32 bits to make room for the weight
-    uint256 cb = (_creationBlock & BLOCKHEIGHT_MAX) << WEIGHT_WIDTH;
+    // then shift left by 32 bits to make room for the id
+    uint256 cb = (_creationBlock & BLOCKHEIGHT_MAX) << ID_WIDTH;
     // Bitwise OR them all together to get
-    // [address operator || uint64 creationBlock || uint32 weight]
-    return (op | cb | wt);
+    // [address operator || uint64 creationBlock || uint32 id]
+    return (op | cb | id);
   }
 
   function operator(uint256 leaf) internal pure returns (address) {
@@ -50,21 +50,12 @@ library Leaf {
 
   /// @notice Return the block number the leaf was created in.
   function creationBlock(uint256 leaf) internal pure returns (uint256) {
-    return ((leaf >> WEIGHT_WIDTH) & BLOCKHEIGHT_MAX);
+    return ((leaf >> ID_WIDTH) & BLOCKHEIGHT_MAX);
   }
 
-  function weight(uint256 leaf) internal pure returns (uint256) {
-    // Weight is stored in the 32 least significant bits.
+  function id(uint256 leaf) internal pure returns (uint256) {
+    // Id is stored in the 32 least significant bits.
     // Bitwise AND ensures that we only get the contents of those bits.
-    require(false, "this should not be called");
-    return (leaf & WEIGHT_MAX);
-  }
-
-  function setWeight(uint256 leaf, uint256 newWeight)
-    internal
-    pure
-    returns (uint256)
-  {
-    return ((leaf & ~WEIGHT_MAX) | (newWeight & WEIGHT_MAX));
+    return (leaf & ID_MAX);
   }
 }

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -99,6 +99,7 @@ contract SortitionPool is AbstractSortitionPool {
 
   function decideFate(
     uint256 leaf,
+    uint256 leafWeight,
     DynamicArray.AddressArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
@@ -108,7 +109,6 @@ contract SortitionPool is AbstractSortitionPool {
       params := paramsPtr
     }
     address operator = leaf.operator();
-    uint256 leafWeight = leaf.weight();
 
     if (!isLeafInitialized(leaf)) {
       return Fate(Decision.Skip, 0);

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -58,7 +58,14 @@ contract SortitionPool is AbstractSortitionPool {
     assembly {
       paramsPtr := params
     }
-    return generalizedSelectGroup(groupSize, seed, paramsPtr, false);
+    uint256[] memory selected = generalizedSelectGroup(
+        groupSize, seed, paramsPtr, false
+    );
+    address[] memory selectedAddresses = new address[](groupSize);
+    for (uint256 i = 0; i < selected.length; i++) {
+        selectedAddresses[i] = selected[i].operator();
+    }
+    return selectedAddresses;
   }
 
   function initializeSelectionParams(uint256 currentMinimumStake)
@@ -100,7 +107,7 @@ contract SortitionPool is AbstractSortitionPool {
   function decideFate(
     uint256 leaf,
     uint256 leafWeight,
-    DynamicArray.AddressArray memory, // `selected`, for future use
+    DynamicArray.UintArray memory, // `selected`, for future use
     uint256 paramsPtr
   ) internal view returns (Fate memory) {
     PoolParams memory params;

--- a/contracts/SortitionTree.sol
+++ b/contracts/SortitionTree.sol
@@ -119,7 +119,7 @@ contract SortitionTree {
 
     uint256 position = getEmptyLeafPosition();
     // Record the block the operator was inserted in
-    uint256 theLeaf = Leaf.make(operator, block.number, weight);
+    uint256 theLeaf = Leaf.make(operator, block.number, id);
 
     root = setLeaf(position, theLeaf, weight, root);
 

--- a/test/contracts/SortitionTreeStub.sol
+++ b/test/contracts/SortitionTreeStub.sol
@@ -3,12 +3,12 @@ pragma solidity 0.5.17;
 import '../../contracts/SortitionTree.sol';
 
 contract SortitionTreeStub is SortitionTree {
-    function publicSetLeaf(uint256 position, uint256 leaf) public {
-        root = setLeaf(position, leaf, root);
+    function publicSetLeaf(uint256 position, uint256 leaf, uint256 weight) public {
+        root = setLeaf(position, leaf, weight, root);
     }
 
     function publicUpdateLeaf(uint256 position, uint256 weight) public {
-        updateLeaf(position, weight);
+        root = updateLeaf(position, weight, root);
     }
 
     function publicRemoveLeaf(uint256 position) public {
@@ -44,7 +44,7 @@ contract SortitionTreeStub is SortitionTree {
     }
 
     function publicPickWeightedLeaf(uint256 index) public view returns (uint256) {
-        (uint256 leafPosition, ) = pickWeightedLeaf(
+        (uint256 leafPosition,,) = pickWeightedLeaf(
             index,
             root
         );

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -30,12 +30,12 @@ contract("SortitionTree", (accounts) => {
       const position2 = parseInt("01234567", 8)
 
       const leaf1 = await sortition.toLeaf.call(alice, weight1)
-      await sortition.publicSetLeaf(position1, leaf1)
+      await sortition.publicSetLeaf(position1, leaf1, weight1)
       const res1 = await sortition.getRoot.call()
       assert.equal(toHex(res1), "0x1234")
 
       const leaf2 = await sortition.toLeaf.call(bob, weight2)
-      await sortition.publicSetLeaf(position2, leaf2)
+      await sortition.publicSetLeaf(position2, leaf2, weight2)
       const res2 = await sortition.getRoot.call()
       assert.equal(toHex(res2), "0x1100001234")
     })
@@ -49,10 +49,10 @@ contract("SortitionTree", (accounts) => {
       const position2 = parseInt("01234567", 8)
 
       const leaf1 = await sortition.toLeaf.call(alice, weight1)
-      await sortition.publicSetLeaf(position1, leaf1)
+      await sortition.publicSetLeaf(position1, leaf1, weight1)
 
       const leaf2 = await sortition.toLeaf.call(bob, weight2)
-      await sortition.publicSetLeaf(position2, leaf2)
+      await sortition.publicSetLeaf(position2, leaf2, weight2)
       await sortition.publicRemoveLeaf(position1)
 
       const root = await sortition.getRoot.call()

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -88,6 +88,20 @@ contract("SortitionTree", (accounts) => {
 
       assert.fail("Expected throw not received")
     })
+
+    it("allocates operator IDs", async () => {
+      await sortition.publicInsertOperator(alice, weightA)
+
+      const aliceID = await sortition.getOperatorID.call(alice)
+      const bobID = await sortition.getOperatorID.call(bob)
+
+      assert.equal(aliceID, 1)
+      assert.equal(bobID, 0)
+
+      const aliceAddress = await sortition.getIDOperator.call(1)
+
+      assert.equal(aliceAddress, alice)
+    })
   })
 
   describe("removeOperator()", async () => {
@@ -114,6 +128,15 @@ contract("SortitionTree", (accounts) => {
       }
 
       assert.fail("Expected throw not received")
+    })
+
+    it("does not remove ID numbers", async () => {
+      await sortition.publicInsertOperator(alice, 0x1234)
+      await sortition.publicRemoveOperator(alice)
+
+      const aliceID = await sortition.getOperatorID.call(alice)
+
+      assert.equal(aliceID, 1)
     })
   })
 


### PR DESCRIPTION
To make large group selections more affordable, a more compact encoding than `address[]` is required for the members. Assigning each member a unique 32-bit ID number in the sortition pool makes storing the members significantly less expensive as 8 members can be packed in a single storage slot.

Each operator is assigned an ID number when they join the pool for the first time. This ID number can be stored in the leaves of the sortition tree, in place of the weight. The weight can be retrieved by querying the branch above the leaf instead. This also makes weight updates slightly cheaper as one fewer storage slot needs to be modified.