### PR TITLE
32 bits: adjusted public API for operator ID, added bitlength checks

### DIFF
--- a/contracts/Leaf.sol
+++ b/contracts/Leaf.sol
@@ -28,6 +28,8 @@ library Leaf {
     uint256 _creationBlock,
     uint256 _id
   ) internal pure returns (uint256) {
+    assert(_creationBlock <= type(uint64).max);
+    assert(_id <= type(uint32).max);
     // Converting a bytesX type into a larger type
     // adds zero bytes on the right.
     uint256 op = uint256(bytes32(bytes20(_operator)));

--- a/contracts/SortitionTree.sol
+++ b/contracts/SortitionTree.sol
@@ -74,6 +74,22 @@ contract SortitionTree {
     return idAddress.length > id ? idAddress[id] : address(0);
   }
 
+  // Gets the operator addresses corresponding to the given ID numbers.
+  // An empty address means the ID number has not been allocated yet.
+  // This function works just like getIDOperator except that it allows to fetch
+  // operator addresses for multiple IDs in one call.
+  function getIDOperators(uint32[] calldata ids)
+    public
+    view
+    returns (address[] memory)
+  {
+    address[] memory operators = new address[](ids.length);
+    for (uint256 i = 0; i < ids.length; i++) {
+      operators[i] = getIDOperator(ids[i]);
+    }
+    return operators;
+  }
+
   // checks if operator is already registered in the pool
   function isOperatorRegistered(address operator) public view returns (bool) {
     return getFlaggedLeafPosition(operator) != 0;

--- a/contracts/SortitionTree.sol
+++ b/contracts/SortitionTree.sol
@@ -51,7 +51,7 @@ contract SortitionTree {
   // Each operator has an uint32 ID number
   // which is allocated when they first join the pool
   // and remains unchanged even if they leave and rejoin the pool.
-  mapping(address => uint256) internal operatorID;
+  mapping(address => uint32) internal operatorID;
   // The idAddress array records the address corresponding to each ID number.
   // The ID number 0 is initialized with a zero address and is not used.
   address[] internal idAddress;
@@ -64,13 +64,13 @@ contract SortitionTree {
 
   // Return the ID number of the given operator address.
   // An ID number of 0 means the operator has not been allocated an ID number yet.
-  function getOperatorID(address operator) public view returns (uint256) {
+  function getOperatorID(address operator) public view returns (uint32) {
     return operatorID[operator];
   }
 
   // Get the operator address corresponding to the given ID number.
   // An empty address means the ID number has not been allocated yet.
-  function getIDOperator(uint256 id) public view returns (address) {
+  function getIDOperator(uint32 id) public view returns (address) {
     return idAddress.length > id ? idAddress[id] : address(0);
   }
 
@@ -101,7 +101,10 @@ contract SortitionTree {
   // Does not check if the operator already has an ID number
   function allocateOperatorID(address operator) internal returns (uint256) {
     uint256 id = idAddress.length;
-    operatorID[operator] = id;
+
+    require(id <= type(uint32).max, "Pool capacity exceeded");
+
+    operatorID[operator] = uint32(id);
     idAddress.push(operator);
     return id;
   }

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -275,23 +275,22 @@ describe("SortitionTree", () => {
 
   describe("getIDOperators", async () => {
     it("returns operator addresses", async () => {
-      const weight = 0xfff
-      await sortition.publicInsertOperator(alice, weight)
-      await sortition.publicInsertOperator(bob, weight)
+      await sortition.publicInsertOperator(alice.address, 0xfff)
+      await sortition.publicInsertOperator(bob.address, 0x123)
 
       const aliceID = 1
       const bobID = 2
       const unknownID = 9
 
-      const addresses = await sortition.getIDOperators.call([
+      const addresses = await sortition.getIDOperators([
         aliceID,
         unknownID,
         bobID,
       ])
-      assert.equal(addresses.length, 3)
-      assert.equal(addresses[0], alice)
-      assert.equal(addresses[1], 0x0)
-      assert.equal(addresses[2], bob)
+      expect(addresses.length).to.equal(3)
+      expect(addresses[0]).to.equal(alice.address)
+      expect(addresses[1]).to.equal(ZERO_ADDRESS)
+      expect(addresses[2]).to.equal(bob.address)
     })
   })
 })

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -272,4 +272,26 @@ describe("SortitionTree", () => {
       })
     })
   })
+
+  describe("getIDOperators", async () => {
+    it("returns operator addresses", async () => {
+      const weight = 0xfff
+      await sortition.publicInsertOperator(alice, weight)
+      await sortition.publicInsertOperator(bob, weight)
+
+      const aliceID = 1
+      const bobID = 2
+      const unknownID = 9
+
+      const addresses = await sortition.getIDOperators.call([
+        aliceID,
+        unknownID,
+        bobID,
+      ])
+      assert.equal(addresses.length, 3)
+      assert.equal(addresses[0], alice)
+      assert.equal(addresses[1], 0x0)
+      assert.equal(addresses[2], bob)
+    })
+  })
 })


### PR DESCRIPTION
`Leaf.make` expects ID to fit in 32 bits but we were not asserting anywhere
if this is really the case. From now on, when a new operator joins the
pool we check if the max capacity was not exceeded and we assert
whether ID fits in 32 bits and creation block fits in 64 bits.

Additionally, `getOperatorID` and `getIDOperator` functions operate now
on `uint32` officially. This is how the external code stores group
members data (see https://github.com/keep-network/keep-core/pull/2677) and it makes sense to
have public sortition pool API reflecting it, even though internally,
for gas efficiency purposes, sortition pool can work on `uint256` IDs.

Last but not least, I took an opportunity and added a function allowing to 
fetch operator addresses by their IDs in one call: `getIDOperators`.
Sometimes it is needed to fetch addresses of all operators in the group
based on their IDs. One example is the random beacon DKG result validation
code that needs to do `ecrocover` on received signatures. To avoid
doing external contract call in a loop, `getIDOperators` allows fetching
addresses in just one call.

~~NOTE: Tests are failing with a mysterious internal test suite error. I did some
investigation and I am pretty sure `@nomiclabs/buidler` does not understand
everything from Solidity 0.8 and errors are happening when we use
`type(uint32).max`. We need to migrate sortition pools to Hardhat 
and @tomaszslabon is working on it. Until his changes lands in `main`,
this PR is blocked.~~