### PR TITLE
Transfer ownership mechanism

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -25,6 +25,11 @@ contract SortitionPool is SortitionTree {
 
   PoolParams internal poolParams;
 
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
   constructor(
     IStaking _stakingContract,
     uint256 _minimumStake,
@@ -93,6 +98,19 @@ contract SortitionPool is SortitionTree {
     } else {
       updateOperator(operator, eligibleWeight);
     }
+  }
+
+  /// @notice Transfers the ownership of the sortition pool.
+  /// @dev Can be called only by the contract owner.
+  /// @param newOwner Address of the new pool owner.
+  function transferOwnership(address newOwner) public {
+    require(msg.sender == poolParams.owner, "Caller is not the owner");
+    require(newOwner != address(0), "New owner is the zero address");
+
+    address oldOwner = poolParams.owner;
+    poolParams.owner = newOwner;
+
+    emit OwnershipTransferred(oldOwner, newOwner);
   }
 
   /// @notice Return whether the operator is eligible for the pool.

--- a/contracts/SortitionPoolFactory.sol
+++ b/contracts/SortitionPoolFactory.sol
@@ -15,12 +15,11 @@ contract SortitionPoolFactory {
     uint256 minimumStake,
     uint256 poolWeightDivisor
   ) public returns (address) {
-    SortitionPool sortitionPool =
-      new SortitionPool(
-        stakingContract,
-        minimumStake,
-        poolWeightDivisor
-      );
+    SortitionPool sortitionPool = new SortitionPool(
+      stakingContract,
+      minimumStake,
+      poolWeightDivisor
+    );
 
     sortitionPool.transferOwnership(msg.sender);
 

--- a/contracts/SortitionPoolFactory.sol
+++ b/contracts/SortitionPoolFactory.sol
@@ -15,16 +15,16 @@ contract SortitionPoolFactory {
     uint256 minimumStake,
     uint256 poolWeightDivisor
   ) public returns (address) {
-    address sortitionPool = address(
+    SortitionPool sortitionPool =
       new SortitionPool(
         stakingContract,
         minimumStake,
-        poolWeightDivisor,
-        msg.sender
-      )
-    );
+        poolWeightDivisor
+      );
 
-    emit SortitionPoolCreated(sortitionPool);
-    return sortitionPool;
+    sortitionPool.transferOwnership(msg.sender);
+
+    emit SortitionPoolCreated(address(sortitionPool));
+    return address(sortitionPool);
   }
 }

--- a/contracts/SortitionPoolStub.sol
+++ b/contracts/SortitionPoolStub.sol
@@ -6,14 +6,12 @@ contract SortitionPoolStub is SortitionPool {
   constructor(
     IStaking _stakingContract,
     uint256 _minimumStake,
-    uint256 _poolWeightDivisor,
-    address _poolOwner
+    uint256 _poolWeightDivisor
   )
     SortitionPool(
       _stakingContract,
       _minimumStake,
-      _poolWeightDivisor,
-      _poolOwner
+      _poolWeightDivisor
     )
   {}
 

--- a/contracts/SortitionPoolStub.sol
+++ b/contracts/SortitionPoolStub.sol
@@ -7,13 +7,7 @@ contract SortitionPoolStub is SortitionPool {
     IStaking _stakingContract,
     uint256 _minimumStake,
     uint256 _poolWeightDivisor
-  )
-    SortitionPool(
-      _stakingContract,
-      _minimumStake,
-      _poolWeightDivisor
-    )
-  {}
+  ) SortitionPool(_stakingContract, _minimumStake, _poolWeightDivisor) {}
 
   function nonViewSelectGroup(uint256 groupSize, bytes32 seed)
     public

--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,9 +5933,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
-      "integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
+      "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
     },
     "@openzeppelin/test-helpers": {
       "version": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/keep-network/sortition-pools#readme",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.4.0"
+    "@openzeppelin/contracts": "^4.3.2"
   },
   "devDependencies": {
     "@keep-network/hardhat-helpers": "^0.2.0-pre",

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -35,7 +35,7 @@ describe("SortitionPool", () => {
     pool = await SortitionPoolStub.deploy(
       staking.address,
       minStake,
-      poolWeightDivisor
+      poolWeightDivisor,
     )
     await pool.deployed()
 


### PR DESCRIPTION
The sortition pool owner should be able to transfer the pool ownership to someone else. The first use case is beacon v2 where `RandomBeacon` contract needs to be the owner of the sortition pool but, in the same time, accepts the pool as a constructor param. This way the right pool owner can not be set upon pool deployment.