### PR TITLE
Pool locking mechanism

### DIFF
--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -1,6 +1,6 @@
 const chai = require("chai")
 const expect = chai.expect
-const { helpers, ethers } = require("hardhat")
+const { ethers } = require("hardhat")
 
 describe("SortitionPool", () => {
   const seed =

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -229,18 +229,13 @@ describe("SortitionPool", () => {
 
   describe("updateOperatorStatus", () => {
     let aliceID
-    let bobID
 
     beforeEach(async () => {
       await staking.setStake(alice.address, 2000)
-      await staking.setStake(bob.address, 4000000)
       await pool.connect(owner).insertOperator(alice.address)
-      await pool.connect(owner).insertOperator(bob.address)
 
       aliceID = await pool.getOperatorID(alice.address)
-      bobID = await pool.getOperatorID(bob.address)
 
-      await staking.setStake(bob.address, 390000)
       await staking.setStake(alice.address, 1000)
 
       await helpers.time.mineBlocks(11)
@@ -249,20 +244,11 @@ describe("SortitionPool", () => {
     context("when sortition pool is unlocked", () => {
       context("when called by the owner", () => {
         beforeEach(async () => {
-          await pool.connect(owner).updateOperatorStatus(bobID)
           await pool.connect(owner).updateOperatorStatus(aliceID)
         })
 
-        it("should update operators status", async () => {
-          const group = await pool.connect(owner).selectGroup(5, seed)
-          await pool.connect(owner).nonViewSelectGroup(5, seed)
-          expect(group).to.deep.equal([
-            bob.address,
-            bob.address,
-            bob.address,
-            bob.address,
-            bob.address,
-          ])
+        it("should update operator status", async () => {
+          expect(await pool.isOperatorUpToDate(alice.address)).to.be.true
         })
       })
 

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -288,105 +288,24 @@ describe("SortitionPool", () => {
     })
   })
 
-  describe("beginMinimumStakeUpdate", () => {
+  describe("updateMinimumStake", () => {
     context("when the caller is the owner", () => {
-      const currentMinimumStake = minStake
       const newMinimumStake = 4000
-      let tx
 
       beforeEach(async () => {
-        tx = await pool.connect(owner).beginMinimumStakeUpdate(newMinimumStake)
+        await pool.connect(owner).updateMinimumStake(newMinimumStake)
       })
 
-      it("should not update the minimum stake immediately", async () => {
-        expect(await pool.minimumStake()).to.be.equal(currentMinimumStake)
-      })
-
-      it("should start the governance delay timer", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-
-        expect(await pool.minimumStakeChangeInitiated()).to.be.equal(
-          blockTimestamp,
-        )
-      })
-
-      it("should emit the MinimumStakeUpdateStarted event", async () => {
-        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
-          .timestamp
-        await expect(tx)
-          .to.emit(pool, "MinimumStakeUpdateStarted")
-          .withArgs(newMinimumStake, blockTimestamp)
+      it("should update the minimum stake immediately", async () => {
+        expect(await pool.minimumStake()).to.be.equal(newMinimumStake)
       })
     })
 
     context("when the caller is not the owner", () => {
       it("should revert", async () => {
         await expect(
-          pool.connect(alice).beginMinimumStakeUpdate(4000),
+          pool.connect(alice).updateMinimumStake(4000),
         ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-  })
-
-  describe("finalizeMinimumStakeUpdate", () => {
-    const newMinimumStake = 4000
-
-    context(
-      "when the update process is initialized, governance delay passed, " +
-        "and the caller is the owner",
-      () => {
-        let tx
-
-        beforeEach(async () => {
-          await pool.connect(owner).beginMinimumStakeUpdate(newMinimumStake)
-
-          await helpers.time.increaseTime(172800) // +48h contract governance delay
-
-          tx = await pool.connect(owner).finalizeMinimumStakeUpdate()
-        })
-
-        it("should update the minimum stake", async () => {
-          expect(await pool.minimumStake()).to.be.equal(newMinimumStake)
-        })
-
-        it("should emit MinimumStakeUpdated event", async () => {
-          await expect(tx)
-            .to.emit(pool, "MinimumStakeUpdated")
-            .withArgs(newMinimumStake)
-        })
-
-        it("should reset the governance delay timer", async () => {
-          expect(await pool.minimumStakeChangeInitiated()).to.be.equal(0)
-        })
-      },
-    )
-
-    context("when the governance delay is not passed", () => {
-      it("should revert", async () => {
-        await pool.connect(owner).beginMinimumStakeUpdate(newMinimumStake)
-
-        await helpers.time.increaseTime(169200) // +47h
-
-        await expect(
-          pool.connect(owner).finalizeMinimumStakeUpdate(),
-        ).to.be.revertedWith("Governance delay has not elapsed")
-      })
-    })
-
-    context("when the caller is not the owner", () => {
-      it("should revert", async () => {
-        await expect(
-          pool.connect(alice).finalizeMinimumStakeUpdate(),
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when the update process is not initialized", () => {
-      it("should revert", async () => {
-        await expect(
-          pool.connect(owner).finalizeMinimumStakeUpdate(),
-        ).to.be.revertedWith("Change not initiated")
       })
     })
   })

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -270,7 +270,7 @@ describe("SortitionPool", () => {
         it("should revert", async () => {
           await expect(
             pool.connect(alice).updateOperatorStatus(aliceID),
-          ).to.be.revertedWith("Caller is not the owner")
+          ).to.be.revertedWith("Ownable: caller is not the owner")
         })
       })
     })

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -237,8 +237,6 @@ describe("SortitionPool", () => {
       aliceID = await pool.getOperatorID(alice.address)
 
       await staking.setStake(alice.address, 1000)
-
-      await helpers.time.mineBlocks(11)
     })
 
     context("when sortition pool is unlocked", () => {


### PR DESCRIPTION
Sortition pool should expose a way to enable and disable the locked state in which operators cannot be inserted, removed, and updated. The first use case is beacon v2 where `RandomBeacon` contract needs to lock the pool during group creation process.