### PR TITLE
Return operator IDs from `selectGroup`

### DIFF
--- a/contracts/Leaf.sol
+++ b/contracts/Leaf.sol
@@ -55,9 +55,9 @@ library Leaf {
     return ((leaf >> ID_WIDTH) & BLOCKHEIGHT_MAX);
   }
 
-  function id(uint256 leaf) internal pure returns (uint256) {
+  function id(uint256 leaf) internal pure returns (uint32) {
     // Id is stored in the 32 least significant bits.
     // Bitwise AND ensures that we only get the contents of those bits.
-    return (leaf & ID_MAX);
+    return uint32(leaf & ID_MAX);
   }
 }

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -181,7 +181,7 @@ contract SortitionPool is SortitionTree, Ownable {
     uint32[] memory selectedIDs = new uint32[](groupSize);
 
     for (uint256 i = 0; i < groupSize; i++) {
-      selectedIDs[i] = getOperatorID(selected.array[i].operator());
+      selectedIDs[i] = uint32(selected.array[i].id());
     }
     return selectedIDs;
   }

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -155,7 +155,7 @@ contract SortitionPool is SortitionTree, Ownable {
     public
     view
     onlyOwner
-    returns (address[] memory)
+    returns (uint32[] memory)
   {
     uint256 _root = root;
 
@@ -178,12 +178,12 @@ contract SortitionPool is SortitionTree, Ownable {
       selected.arrayPush(leaf);
     }
 
-    address[] memory selectedAddresses = new address[](groupSize);
+    uint32[] memory selectedIDs = new uint32[](groupSize);
 
     for (uint256 i = 0; i < groupSize; i++) {
-      selectedAddresses[i] = selected.array[i].operator();
+      selectedIDs[i] = getOperatorID(selected.array[i].operator());
     }
-    return selectedAddresses;
+    return selectedIDs;
   }
 
   /// @notice Return the eligible weight of the operator,

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -181,7 +181,7 @@ contract SortitionPool is SortitionTree, Ownable {
     uint32[] memory selectedIDs = new uint32[](groupSize);
 
     for (uint256 i = 0; i < groupSize; i++) {
-      selectedIDs[i] = uint32(selected.array[i].id());
+      selectedIDs[i] = selected.array[i].id();
     }
     return selectedIDs;
   }

--- a/contracts/SortitionPoolStub.sol
+++ b/contracts/SortitionPoolStub.sol
@@ -11,7 +11,7 @@ contract SortitionPoolStub is SortitionPool {
 
   function nonViewSelectGroup(uint256 groupSize, bytes32 seed)
     public
-    returns (address[] memory)
+    returns (uint32[] memory)
   {
     return selectGroup(groupSize, seed);
   }

--- a/test/factoryTest.js
+++ b/test/factoryTest.js
@@ -8,7 +8,9 @@ describe("SortitionPoolFactory", () => {
   const minStake = 2000
   const poolWeightDivisor = 2000
   let alice
+  let aliceID
   let bob
+  let bobID
   let staking
   let factory
 
@@ -63,13 +65,16 @@ describe("SortitionPoolFactory", () => {
       await sortitionPool1.insertOperator(alice.address)
       await sortitionPool2.insertOperator(bob.address)
 
+      aliceID = await sortitionPool1.getOperatorID(alice.address)
+      bobID = await sortitionPool2.getOperatorID(bob.address)
+
       await helpers.time.mineBlocks(11)
 
       const group1 = await sortitionPool1.selectGroup(2, seed)
-      expect(group1).to.deep.equal([alice.address, alice.address])
+      expect(group1).to.deep.equal([aliceID, aliceID])
 
       const group2 = await sortitionPool2.selectGroup(2, seed)
-      expect(group2).to.deep.equal([bob.address, bob.address])
+      expect(group2).to.deep.equal([bobID, bobID])
     })
   })
 })


### PR DESCRIPTION
This change makes usage of `selectGroup` easier as operators are now represented by IDs. This change should reduce the number of `address <-> ID` conversions done by the client code.