### PR TITLE
Updates to operator API

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -18,8 +18,6 @@ contract SortitionPool is SortitionTree, Ownable {
 
   uint256 public immutable poolWeightDivisor;
 
-  uint256 public minimumStake;
-
   bool public isLocked;
 
   /// @notice Reverts if called while pool is locked.
@@ -98,13 +96,6 @@ contract SortitionPool is SortitionTree, Ownable {
     onlyOwner
   {
     // TODO: Implementation
-  }
-
-  /// @notice Updates the minimum stake value,
-  /// @dev Can be called only by the contract owner.
-  /// @param newMinimumStake New minimum stake value.
-  function updateMinimumStake(uint256 newMinimumStake) external onlyOwner {
-    minimumStake = newMinimumStake;
   }
 
   /// @notice Return whether the operator is present in the pool.

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -63,6 +63,25 @@ contract SortitionPool is SortitionTree, Ownable {
     _insertOperator(operator, weight);
   }
 
+  /// @notice Update the operator's weight if present and eligible,
+  /// or remove from the pool if present and ineligible.
+  /// @dev Can be called only by the contract owner.
+  /// @param operator Address of the updated operator.
+  /// @param authorizedStake Operator's authorized stake for the application.
+  function updateOperatorStatus(address operator, uint256 authorizedStake)
+    public
+    onlyOwner
+    onlyUnlocked
+  {
+    uint256 weight = getWeight(authorizedStake);
+
+    if (weight == 0) {
+      _removeOperator(operator);
+    } else {
+      updateOperator(operator, weight);
+    }
+  }
+
   /// @notice Removes an operator from the pool.
   /// @dev Can be called only by the contract owner.
   /// @param id ID of the removed operator.
@@ -82,27 +101,6 @@ contract SortitionPool is SortitionTree, Ownable {
 
     for (uint256 i = 0; i < operators.length; i++) {
       _removeOperator(operators[i]);
-    }
-  }
-
-  /// @notice Update the operator's weight if present and eligible,
-  /// or remove from the pool if present and ineligible.
-  /// @dev Can be called only by the contract owner.
-  /// @param id ID of the updated operator.
-  /// @param authorizedStake Operator's authorized stake for the application.
-  function updateOperatorStatus(uint32 id, uint256 authorizedStake)
-    public
-    onlyOwner
-    onlyUnlocked
-  {
-    address operator = getIDOperator(id);
-
-    uint256 weight = getWeight(authorizedStake);
-
-    if (weight == 0) {
-      _removeOperator(operator);
-    } else {
-      updateOperator(operator, weight);
     }
   }
 

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -84,9 +84,9 @@ contract SortitionPool is SortitionTree, Ownable {
 
   /// @notice Removes an operator from the pool.
   /// @dev Can be called only by the contract owner.
-  /// @param id ID of the removed operator.
-  function removeOperator(uint32 id) public onlyOwner onlyUnlocked {
-    _removeOperator(getIDOperator(id));
+  /// @param operator Address of the operator to be removed.
+  function removeOperator(address operator) public onlyOwner onlyUnlocked {
+    _removeOperator(operator);
   }
 
   /// @notice Ban rewards for given operators for given period of time.

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -89,21 +89,6 @@ contract SortitionPool is SortitionTree, Ownable {
     _removeOperator(getIDOperator(id));
   }
 
-  /// @notice Removes given operators from the pool.
-  /// @dev Can be called only by the contract owner.
-  /// @param ids IDs of the removed operators.
-  function removeOperators(uint32[] calldata ids)
-    public
-    onlyOwner
-    onlyUnlocked
-  {
-    address[] memory operators = getIDOperators(ids);
-
-    for (uint256 i = 0; i < operators.length; i++) {
-      _removeOperator(operators[i]);
-    }
-  }
-
   /// @notice Ban rewards for given operators for given period of time.
   /// @dev Can be called only by the contract owner.
   /// @param operators IDs of banned operators.

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -218,28 +218,6 @@ describe("SortitionPool", () => {
     })
   })
 
-  describe("updateMinimumStake", () => {
-    context("when the caller is the owner", () => {
-      const newMinimumStake = 4000
-
-      beforeEach(async () => {
-        await pool.connect(owner).updateMinimumStake(newMinimumStake)
-      })
-
-      it("should update the minimum stake immediately", async () => {
-        expect(await pool.minimumStake()).to.be.equal(newMinimumStake)
-      })
-    })
-
-    context("when the caller is not the owner", () => {
-      it("should revert", async () => {
-        await expect(
-          pool.connect(alice).updateMinimumStake(4000),
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-  })
-
   describe("selectGroup", async () => {
     context("when called by owner", () => {
       beforeEach(async () => {

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -125,17 +125,15 @@ describe("SortitionPool", () => {
   })
 
   describe("removeOperator", () => {
-    let aliceID
-
     beforeEach(async () => {
       await pool.connect(owner).insertOperator(alice.address, 20000)
-      aliceID = await pool.getOperatorID(alice.address)
+      await pool.getOperatorID(alice.address)
     })
 
     context("when sortition pool is unlocked", () => {
       context("when called by the owner", () => {
         beforeEach(async () => {
-          await pool.connect(owner).removeOperator(aliceID)
+          await pool.connect(owner).removeOperator(alice.address)
         })
 
         it("should remove the operator from the pool", async () => {
@@ -146,7 +144,7 @@ describe("SortitionPool", () => {
       context("when called by a non-owner", () => {
         it("should revert", async () => {
           await expect(
-            pool.connect(alice).removeOperator(aliceID),
+            pool.connect(alice).removeOperator(alice.address),
           ).to.be.revertedWith("Ownable: caller is not the owner")
         })
       })
@@ -159,7 +157,7 @@ describe("SortitionPool", () => {
 
       it("should revert", async () => {
         await expect(
-          pool.connect(owner).removeOperator(aliceID),
+          pool.connect(owner).removeOperator(alice.address),
         ).to.be.revertedWith("Sortition pool locked")
       })
     })

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -214,19 +214,15 @@ describe("SortitionPool", () => {
   })
 
   describe("updateOperatorStatus", () => {
-    let aliceID
-
     beforeEach(async () => {
       await pool.connect(owner).insertOperator(alice.address, 2000)
-
-      aliceID = await pool.getOperatorID(alice.address)
     })
 
     context("when sortition pool is unlocked", () => {
       context("when called by the owner", () => {
         context("when operator is still eligible", () => {
           beforeEach(async () => {
-            await pool.connect(owner).updateOperatorStatus(aliceID, 5000)
+            await pool.connect(owner).updateOperatorStatus(alice.address, 5000)
           })
 
           it("should update operator status", async () => {
@@ -241,7 +237,7 @@ describe("SortitionPool", () => {
           beforeEach(async () => {
             await pool
               .connect(owner)
-              .updateOperatorStatus(aliceID, poolWeightDivisor - 1)
+              .updateOperatorStatus(alice.address, poolWeightDivisor - 1)
           })
 
           it("should remove operator from the pool", async () => {
@@ -253,7 +249,7 @@ describe("SortitionPool", () => {
       context("when called by a non-owner", () => {
         it("should revert", async () => {
           await expect(
-            pool.connect(alice).updateOperatorStatus(aliceID, 10000),
+            pool.connect(alice).updateOperatorStatus(alice.address, 10000),
           ).to.be.revertedWith("Ownable: caller is not the owner")
         })
       })
@@ -266,7 +262,7 @@ describe("SortitionPool", () => {
 
       it("should revert", async () => {
         await expect(
-          pool.connect(owner).updateOperatorStatus(aliceID, 10000),
+          pool.connect(owner).updateOperatorStatus(alice.address, 10000),
         ).to.be.revertedWith("Sortition pool locked")
       })
     })

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -165,54 +165,6 @@ describe("SortitionPool", () => {
     })
   })
 
-  describe("removeOperators", () => {
-    let bobID
-    let carolID
-
-    beforeEach(async () => {
-      await pool.connect(owner).insertOperator(alice.address, 20000)
-      await pool.connect(owner).insertOperator(bob.address, 20000)
-      await pool.connect(owner).insertOperator(carol.address, 20000)
-
-      bobID = await pool.getOperatorID(bob.address)
-      carolID = await pool.getOperatorID(carol.address)
-    })
-
-    context("when sortition pool is unlocked", () => {
-      context("when called by the owner", () => {
-        beforeEach(async () => {
-          await pool.connect(owner).removeOperators([bobID, carolID])
-        })
-
-        it("should remove given operators from the pool", async () => {
-          expect(await pool.isOperatorInPool(alice.address)).to.be.true
-          expect(await pool.isOperatorInPool(bob.address)).to.be.false
-          expect(await pool.isOperatorInPool(carol.address)).to.be.false
-        })
-      })
-
-      context("when called by a non-owner", () => {
-        it("should revert", async () => {
-          await expect(
-            pool.connect(alice).removeOperators([bobID, carolID]),
-          ).to.be.revertedWith("Ownable: caller is not the owner")
-        })
-      })
-    })
-
-    context("when sortition pool is locked", () => {
-      beforeEach(async () => {
-        await pool.connect(owner).lock()
-      })
-
-      it("should revert", async () => {
-        await expect(
-          pool.connect(owner).removeOperators([bobID, carolID]),
-        ).to.be.revertedWith("Sortition pool locked")
-      })
-    })
-  })
-
   describe("updateOperatorStatus", () => {
     beforeEach(async () => {
       await pool.connect(owner).insertOperator(alice.address, 2000)


### PR DESCRIPTION
Depends on #135 
Refs https://github.com/keep-network/keep-core/issues/2715

Updates to the operator-related API needed to integrate with T staking contract.

Changes included:

- Update operator status using its address 

  Instead of using operator id as a parameter we need to use operator
address. T staking contract calls
`authorizationIncreased(address operator, uint256 amount)`
on the authorized application so there is no point in going from
address to id, and then from id to address again.

- Remove operator from the pool using its address

  Instead of using operator id as a parameter, we need to use operator
address. T staking contract calls
`authorizationDecreaseRequested(address operator, uint96 amount)`
on the authorized application when the given operator requests to
decrease its authorization so there is no point in going from address
to id and then again from id to address.

- Deleted `removeOperators` function

  Instead of removing misbehaving operators from the pool, we will
ban them from receiving rewards. Thus, the batch function for
removing them is no longer needed.

Additionally, removed unused `SortitionPool.minimumStake` field.
As a result of changes in #135, `SortitionPool` does no longer need
a reference to the staking contract and is no longer checking if
the given operator is eligible to join - this is a responsibility
of the application now. The minimum stake field in `SortitionPool` was
overlooked during these changes - cleaning up now.