### PR TITLE
Removed onlyOwner modifier from selectGroup function

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -136,7 +136,6 @@ contract SortitionPool is SortitionTree, Ownable {
   function selectGroup(uint256 groupSize, bytes32 seed)
     public
     view
-    onlyOwner
     returns (uint32[] memory)
   {
     uint256 _root = root;

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -219,7 +219,7 @@ describe("SortitionPool", () => {
   })
 
   describe("selectGroup", async () => {
-    context("when called by owner", () => {
+    context("when there is enough operators in pool", () => {
       beforeEach(async () => {
         await pool.connect(owner).insertOperator(alice.address, 20000)
         await pool.connect(owner).insertOperator(bob.address, 22000)
@@ -230,20 +230,6 @@ describe("SortitionPool", () => {
         const group = await pool.connect(owner).selectGroup(3, seed)
         await pool.connect(owner).selectGroup(3, seed)
         expect(group.length).to.be.equal(3)
-      })
-    })
-
-    context("when called by non-owner", () => {
-      beforeEach(async () => {
-        await pool.connect(owner).insertOperator(alice.address, 20000)
-        await pool.connect(owner).insertOperator(bob.address, 22000)
-        await pool.connect(owner).insertOperator(carol.address, 24000)
-      })
-
-      it("should revert", async () => {
-        await expect(
-          pool.connect(alice).selectGroup(3, seed),
-        ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
 


### PR DESCRIPTION
Everyone should be able to call `selectGroup` to confirm if DKG result
submitted is valid. This is especially important in the optimistic
mode when result is submitted without on-chain validation, and then
potentially challenged.