### PR TITLE
Added `SortitionPool.updateOperatorStatusAndRewards` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   ],
   "scripts": {
     "build": "hardhat compile",
-    "ganache": "echo 'GANACHE IS NO LONGER USED; use buidler-vm script instead'",
     "test": "hardhat test",
     "lint": "npm run lint:js && npm run lint:sol",
     "lint:fix": "npm run lint:fix:js && npm run lint:fix:sol",


### PR DESCRIPTION
__This PR is still in draft as we need to evaluate the impact of this approach
on the `RandomBeacon` application contract._

See the discussion here: https://github.com/keep-network/keep-core/pull/2747#discussion_r765839410_
********

Depends on #142 
Refs https://github.com/keep-network/keep-core/issues/2715

Say we are creating a new group every month and that the group lifetime
is 2 months. Say we have group `a` active and group `b` will soon be
created. Let's say that the operator requests authorization decrease at
`x` moment of time:

```
|---------a-----------|
    x     |---------b----------|
                    |---------c-----------|
```

If we do not remove operator from the sortition pool at `x`, it may happen
that the operator gets selected to group `b` and they might be able to
approve authorization decrease before `b` ends its life. This is not ideal
and it generally feels wrong not to remove the operator from the sortition
pool immediately if we know that operator will be unwinding their node.

If we remove the operator from the pool at `x` they stop earning rewards and
given that the authorization decrease delay needs to be long enough given
the long group lifetime, this situation is less than ideal.

We need to rework rewards so that it is possible to remove someone from the
pool while still giving them a chance to earn rewards. This is addressed in this
change.

We introduce `SortitionPool.updateOperatorStatusAndRewards` function that is
identical to `updateOperatorStatus` except that it allows setting rewards weight
different than the in-pool weight. This will be used for situations just like
the one earlier described: operator is undelegating and they should be removed
from the pool while still earning rewards based on their previous weight until
the undelegation is completed.