### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Run linters
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   lint-js:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Run linters
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint-js:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,26 +10,30 @@ on:
 jobs:
   lint-js:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
+
       - uses: actions/setup-node@v1
         with:
           node-version: "11.x"
+
       - name: Install dependencies
         run: npm install
+        
       - name: Run JS linter
         run: npm run lint:js
 
   lint-sol:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
+
       - uses: actions/setup-node@v1
         with:
           node-version: "11.x"
+
       - name: Install dependencies
         run: npm install
+
       - name: Run Solidity linter
         run: npm run lint:sol

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: "11.x"
+          node-version: "14.x"
 
       - name: Install dependencies
         run: npm install
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: "11.x"
+          node-version: "14.x"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,19 +20,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: Bump up package version
         id: npm-version-bump

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access=public --tag=dev

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -4,6 +4,7 @@ on:
   push:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   run-tests:

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -9,14 +9,17 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
+      
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
+          cache: "npm"
+
       - name: Install dependencies
         run: npm install
+
       - name: Run tests
         run: |
           npm test

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "11.x"
+          node-version: "14.x"
       - name: Install dependencies
         run: npm install
       - name: Run tests


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59