### PR TITLE
Bump up version to `2.0.0-dev`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.2.0-dev",
+  "version": "2.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "1.2.0-dev",
+  "version": "2.0.0-dev",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
We're bumping up version of `@keep-network/sortition-pools` package from
`1.2.0-dev` to `2.0.0-dev`. This has been dictated by the fact that
there were recently major changes regarding sortition pools contracts -
many contracts have been removed and some new got added as well.

If this change gets accepted, we should consider removing packages from `1.2.0-dev.2` to `1.2.0-dev.25` from the npm registry, as they were improperly versioned (they should have been bumped up to `2.0.0-dev...`. After we remove them, we should close https://github.com/keep-network/keep-ecdsa/pull/943.