### PR TITLE
Use `pre` suffix & tag for npm package instead of `dev`

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,11 +27,11 @@ jobs:
         id: npm-version-bump
         uses: keep-network/npm-version-bump@v2
         with:
-          environment: dev
+          environment: pre
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
 
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --tag=dev
+        run: npm publish --access=public --tag=pre

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/sortition-pools",
-  "version": "2.0.0-dev",
+  "version": "2.0.0-pre",
   "description": "",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
We'll be useing a `pre` tag for this package with contracts. We decided
to use 'dev` suffix for projects where we deploy contracts (and there is
a need for distinction between environments). Here we don't deploy
contracts, so we can use `pre` suffix/tag.