### PR TITLE
SortitionPool.withdrawRewards returns the amount of rewards withdrawn 

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -74,6 +74,9 @@ contract SortitionPool is SortitionTree, Rewards, Ownable, IReceiveApproval {
     return earned;
   }
 
+  /// @notice Withdraws rewards not allocated to operators marked as ineligible
+  ///         to the given recipient address.
+  /// @dev Can be called only by the owner.
   function withdrawIneligible(address recipient) public onlyOwner {
     uint96 earned = Rewards.withdrawIneligibleRewards();
     rewardToken.transfer(recipient, uint256(earned));

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -56,14 +56,22 @@ contract SortitionPool is SortitionTree, Rewards, Ownable, IReceiveApproval {
     Rewards.addRewards(uint96(amount), uint32(root.sumWeight()));
   }
 
+  /// @notice Withdraws all available rewards for the given operator to the
+  ///         given beneficiary.
+  /// @dev Can be called only be the owner. Does not validate if the provided
+  ///      beneficiary is associated with the provided operator - this needs to
+  ///      be done by the owner calling this function.
+  /// @return The amount of rewards withdrawn in this call.
   function withdrawRewards(address operator, address beneficiary)
     public
     onlyOwner
+    returns (uint96)
   {
     uint32 id = getOperatorID(operator);
     Rewards.updateOperatorRewards(id, uint32(getPoolWeight(operator)));
     uint96 earned = Rewards.withdrawOperatorRewards(id);
     rewardToken.transfer(beneficiary, uint256(earned));
+    return earned;
   }
 
   function withdrawIneligible(address recipient) public onlyOwner {


### PR DESCRIPTION
~~Depends on https://github.com/keep-network/sortition-pools/pull/162; Please do not merge until #162 is not in `main`.~~

This allows to emit an event in application contract with the amount of
rewards withdrawn. It will be helpful for the dApp when rendering
rewards page.