### PR TITLE
Test the output of `SortitionPool.withdrawRewards`

### DIFF
--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -2,7 +2,12 @@ const chai = require("chai")
 const expect = chai.expect
 const { ethers, helpers } = require("hardhat")
 
-async function withdrawRewards(pool, owner, operatorAddress, beneficiaryAddress) {
+async function withdrawRewards(
+  pool,
+  owner,
+  operatorAddress,
+  beneficiaryAddress,
+) {
   const tx = await pool
     .connect(owner)
     .withdrawRewards(operatorAddress, beneficiaryAddress)
@@ -269,7 +274,7 @@ describe("SortitionPool", () => {
   describe("pool rewards", async () => {
     it("can only be withdrawn by the owner", async () => {
       await expect(
-        withdrawRewards(pool, bob, bob.address, bobBeneficiary.address)
+        withdrawRewards(pool, bob, bob.address, bobBeneficiary.address),
       ).to.be.revertedWith("Ownable: caller is not the owner")
     })
 
@@ -282,8 +287,18 @@ describe("SortitionPool", () => {
       const aliceExpectedReward = 100
       const bobExpectedReward = 200
 
-      const aliceReward = await withdrawRewards(pool, owner, alice.address, aliceBeneficiary.address)
-      const bobReward = await withdrawRewards(pool, owner, bob.address, bobBeneficiary.address)
+      const aliceReward = await withdrawRewards(
+        pool,
+        owner,
+        alice.address,
+        aliceBeneficiary.address,
+      )
+      const bobReward = await withdrawRewards(
+        pool,
+        owner,
+        bob.address,
+        bobBeneficiary.address,
+      )
       expect(aliceReward).to.equal(aliceExpectedReward)
       expect(bobReward).to.equal(bobExpectedReward)
 
@@ -305,8 +320,18 @@ describe("SortitionPool", () => {
       const aliceExpectedReward = 400
       const bobExpectedReward = 500
 
-      const aliceReward = await withdrawRewards(pool, owner, alice.address, aliceBeneficiary.address)
-      const bobReward = await withdrawRewards(pool, owner, bob.address, bobBeneficiary.address)
+      const aliceReward = await withdrawRewards(
+        pool,
+        owner,
+        alice.address,
+        aliceBeneficiary.address,
+      )
+      const bobReward = await withdrawRewards(
+        pool,
+        owner,
+        bob.address,
+        bobBeneficiary.address,
+      )
       expect(aliceReward).to.equal(aliceExpectedReward)
       expect(bobReward).to.equal(bobExpectedReward)
 
@@ -327,8 +352,18 @@ describe("SortitionPool", () => {
       const aliceExpectedReward = 100
       const bobExpectedReward = 0
 
-      const aliceReward = await withdrawRewards(pool, owner, alice.address, aliceBeneficiary.address)
-      const bobReward = await withdrawRewards(pool, owner, bob.address, bobBeneficiary.address)
+      const aliceReward = await withdrawRewards(
+        pool,
+        owner,
+        alice.address,
+        aliceBeneficiary.address,
+      )
+      const bobReward = await withdrawRewards(
+        pool,
+        owner,
+        bob.address,
+        bobBeneficiary.address,
+      )
       expect(aliceReward).to.equal(aliceExpectedReward)
       expect(bobReward).to.equal(bobExpectedReward)
 

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -268,7 +268,9 @@ describe("SortitionPool", () => {
       const amount = await pool
         .connect(owner)
         .callStatic.withdrawRewards(operatorAddress, beneficiaryAddress)
-      await pool.connect(owner).withdrawRewards(operatorAddress, beneficiaryAddress)
+      await pool
+        .connect(owner)
+        .withdrawRewards(operatorAddress, beneficiaryAddress)
       return amount
     }
 

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -265,11 +265,11 @@ describe("SortitionPool", () => {
       operatorAddress,
       beneficiaryAddress,
     ) {
-      const tx = await pool
+      const amount = await pool
         .connect(owner)
-        .withdrawRewards(operatorAddress, beneficiaryAddress)
-      const withdrawLogs = await tx.wait()
-      return parseInt(withdrawLogs.logs[0].data)
+        .callStatic.withdrawRewards(operatorAddress, beneficiaryAddress)
+      await pool.connect(owner).withdrawRewards(operatorAddress, beneficiaryAddress)
+      return amount
     }
 
     it("can only be withdrawn by the owner", async () => {

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -2,19 +2,6 @@ const chai = require("chai")
 const expect = chai.expect
 const { ethers, helpers } = require("hardhat")
 
-async function withdrawRewards(
-  pool,
-  owner,
-  operatorAddress,
-  beneficiaryAddress,
-) {
-  const tx = await pool
-    .connect(owner)
-    .withdrawRewards(operatorAddress, beneficiaryAddress)
-  const withdrawLogs = await tx.wait()
-  return parseInt(withdrawLogs.logs[0].data)
-}
-
 describe("SortitionPool", () => {
   const seed =
     "0xff39d6cca87853892d2854566e883008bc000000000000000000000000000000"
@@ -272,6 +259,19 @@ describe("SortitionPool", () => {
   })
 
   describe("pool rewards", async () => {
+    async function withdrawRewards(
+      pool,
+      owner,
+      operatorAddress,
+      beneficiaryAddress,
+    ) {
+      const tx = await pool
+        .connect(owner)
+        .withdrawRewards(operatorAddress, beneficiaryAddress)
+      const withdrawLogs = await tx.wait()
+      return parseInt(withdrawLogs.logs[0].data)
+    }
+
     it("can only be withdrawn by the owner", async () => {
       await expect(
         withdrawRewards(pool, bob, bob.address, bobBeneficiary.address),


### PR DESCRIPTION
Follow up to #163, we alter `test/sortitionPoolTest.js` to make assertions about the return values of `withdrawRewards`.

Unfortunately since `withdrawRewards` isn't a `view` function we have to extract the return data from the events or logs.

Tagging @pdyraga for review