### PR TITLE
Overhaul the RNG tests

### DIFF
--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -11,7 +11,7 @@ describe("RNG", () => {
 
   describe("bitsRequired", async () => {
     it("Returns the number of bits required", async () => {
-      // Any number higher than 2**32 will just return 32
+      // Any number higher than 2**32 - 1 will return 32
       expect(await rngInstance.bitsRequired(2 ** 32 + 1)).to.be.equal(32)
       expect(await rngInstance.bitsRequired(2 ** 32)).to.be.equal(32)
       expect(await rngInstance.bitsRequired(2 ** 32 - 1)).to.be.equal(32)

--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -11,6 +11,7 @@ describe("RNG", () => {
 
   describe("bitsRequired", async () => {
     it("Returns the number of bits required", async () => {
+      // Any number higher than 2**32 will just return 32
       expect(await rngInstance.bitsRequired(2 ** 32 + 1)).to.be.equal(32)
       expect(await rngInstance.bitsRequired(2 ** 32)).to.be.equal(32)
       expect(await rngInstance.bitsRequired(2 ** 32 - 1)).to.be.equal(32)
@@ -28,6 +29,22 @@ describe("RNG", () => {
       expect(await rngInstance.bitsRequired(2 ** 2 - 1)).to.be.equal(2)
 
       expect(await rngInstance.bitsRequired(2)).to.be.equal(1)
+
+      // Generative Testing
+      const numberOfSamples = 100
+      const maxNumber = 2 ** 32 - 1
+      for (let i = 0; i < numberOfSamples; i++) {
+        const randomNumber = Math.floor(Math.random() * maxNumber)
+        const bitsRequired = await rngInstance.bitsRequired(randomNumber)
+        // We can represent 0 and 1 with 1 bit, 0-3 with 2 bits, 0-7 with 3
+        // bits, etc. Every bit doubles the number of numbers we can represent,
+        // so working backwards is log base 2.
+        const expectation = Math.ceil(Math.log2(randomNumber))
+        expect(bitsRequired).to.equal(
+          expectation,
+          `something went wrong calculating the bits required for ${randomNumber}`,
+        )
+      }
     })
   })
 

--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -50,14 +50,14 @@ describe("RNG", () => {
 
   describe("truncate", async () => {
     it("Truncates a number to the correct number of bits", async () => {
-      a = 0xffffffff
+      const a = 0xffffffff
 
-      b = await rngInstance.truncate(1, a)
-      c = await rngInstance.truncate(2, a)
-      d = await rngInstance.truncate(16, a)
-      e = await rngInstance.truncate(31, a)
-      f = await rngInstance.truncate(32, a)
-      g = await rngInstance.truncate(64, a)
+      const b = await rngInstance.truncate(1, a)
+      const c = await rngInstance.truncate(2, a)
+      const d = await rngInstance.truncate(16, a)
+      const e = await rngInstance.truncate(31, a)
+      const f = await rngInstance.truncate(32, a)
+      const g = await rngInstance.truncate(64, a)
 
       expect(b).to.be.equal(0x1)
       expect(c).to.be.equal(0x3)

--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -104,7 +104,7 @@ describe("RNG", () => {
       // We sample the distribution, and then make sure that the count of any
       // generated number doesn't exceed a tolerance.
 
-      const delta = 10 // percentage degree of inaccuracy to tolerate
+      const delta = 20 // percentage degree of inaccuracy to tolerate
       const maxSeed = 2 ** 32
 
       // Use a low number of possible outcomes but a large number of samples to
@@ -112,7 +112,7 @@ describe("RNG", () => {
       // Higher number of possible outcomes would require higher number of
       // samples.
       const maxNumber = 6
-      const numSamples = 10000
+      const numSamples = 1000
       const count = {}
       for (let i = 0; i < numSamples; i++) {
         const val = await rngInstance.getIndex(

--- a/test/rngTest.js
+++ b/test/rngTest.js
@@ -65,6 +65,23 @@ describe("RNG", () => {
       expect(e).to.be.equal(0x7fffffff)
       expect(f).to.be.equal(a)
       expect(g).to.be.equal(a)
+
+      // Generative Testing
+      const numberOfSamples = 3
+      const maxNumber = 2 ** 32 - 1
+      for (let i = 0; i < numberOfSamples; i++) {
+        // Truncating to `bits` is mathematically equivalent to
+        // `number % (2 ** bits)`
+        for (let bits = 1; bits < 65; bits++) {
+          const randomNumber = Math.floor(Math.random() * maxNumber)
+          const truncatedNumber = await rngInstance.truncate(bits, randomNumber)
+          const expectation = randomNumber % 2 ** bits
+          expect(truncatedNumber).to.be.equal(
+            expectation,
+            `something went wrong truncating ${randomNumber} to ${bits} bits`,
+          )
+        }
+      }
     })
   })
 


### PR DESCRIPTION
This PR gives the RNG tests some love and care, adding generative testing where useful, as well as adding an assertion that the results from `getIndex` actually are uniform.

Tagging @pdyraga @eth-r @lukasz-zimnoch and @michalinacienciala for review

Refs #161 