### PR TITLE
Sortition Tree Tests

### DIFF
--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -113,13 +113,22 @@ describe("SortitionTree", () => {
   describe("insertOperator", () => {
     const weightA = 0xfff0
     const weightB = 0x10000001
+    // weightA + weightB = 0x1000fff1
 
     context("when operators are inserted", () => {
       it("should return correct value for the tree", async () => {
+        // insertion begins left to right, so alice is inserted at position 0,
+        // and bob is inserted at position 1. Their weights will propagate to
+        // the root's first slot.
         await sortition.publicInsertOperator(alice.address, weightA)
         await sortition.publicInsertOperator(bob.address, weightB)
         const root = await sortition.getRoot()
-        expect(ethers.utils.hexlify(root)).to.be.equal("0x1000fff1")
+        expect(ethers.utils.hexlify(root)).to.be.equal("0x1000fff1") // weightA + weightB
+        // The full output here looks like
+        // 0x00000000,00000000,00000000,00000000,00000000,00000000,00000000,1000fff1
+        //  slot 7     slot 6   slot 5   slot 4   slot 3   slot 2   slot 1   slot 0
+        // without the commas added for readability. All the padding zeros are
+        // dropped when we hexlify, which simplifies to 0x1100000000.
       })
     })
 

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -88,9 +88,10 @@ describe("SortitionTree", () => {
     context("when leaf is removed", () => {
       it("should return correct value for the tree", async () => {
         const weight1 = 0x1234
-        const position1 = parseInt("00123456", 8)
+        const position1 = 42798
+
         const weight2 = 0x11
-        const position2 = parseInt("01234567", 8)
+        const position2 = 342391
 
         const leaf1 = await sortition.toLeaf(alice.address, weight1)
         await sortition.publicSetLeaf(position1, leaf1, weight1)
@@ -100,6 +101,11 @@ describe("SortitionTree", () => {
         await sortition.publicRemoveLeaf(position1)
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x1100000000")
+        // The full output here looks like
+        // 0x00000000,00000000,00000000,00000000,00000000,00000000,00000011,00000000
+        //  slot 7     slot 6   slot 5   slot 4   slot 3   slot 2   slot 1   slot 0
+        // without the commas added for readability. All the padding zeros are
+        // dropped when we hexlify, which simplifies to 0x1100000000.
       })
     })
   })

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -267,6 +267,8 @@ describe("SortitionTree", () => {
       const index1 = 450
       const index2 = 451
 
+      // alice is assigned weights [0-450] (451 values) and bob has weight
+      // [451-2434] (1984 values).
       const position1 = await sortition.publicPickWeightedLeaf(index1)
       expect(position1).to.be.equal(0)
 

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -19,22 +19,19 @@ describe("SortitionTree", () => {
 
   describe("setLeaf", async () => {
     context("when one leaf is set", () => {
-      beforeEach(async () => {
+      it("should return correct value for the tree", async () => {
         const weight1 = 0x1234
         const position1 = parseInt("00123456", 8)
 
         const leaf = await sortition.toLeaf(alice.address, weight1)
         await sortition.publicSetLeaf(position1, leaf, weight1)
-      })
-
-      it("should return correct value for the tree", async () => {
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x1234")
       })
     })
 
     context("when two leaves are set", () => {
-      beforeEach(async () => {
+      it("should return correct value for the tree", async () => {
         const weight1 = 0x1234
         const position1 = parseInt("00123456", 8)
         const weight2 = 0x11
@@ -45,9 +42,6 @@ describe("SortitionTree", () => {
 
         const leaf2 = await sortition.toLeaf(bob.address, weight2)
         await sortition.publicSetLeaf(position2, leaf2, weight2)
-      })
-
-      it("should return correct value for the tree", async () => {
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x1100001234")
       })
@@ -56,7 +50,7 @@ describe("SortitionTree", () => {
 
   describe("removeLeaf", () => {
     context("when leaf is removed", () => {
-      beforeEach(async () => {
+      it("should return correct value for the tree", async () => {
         const weight1 = 0x1234
         const position1 = parseInt("00123456", 8)
         const weight2 = 0x11
@@ -68,9 +62,6 @@ describe("SortitionTree", () => {
         const leaf2 = await sortition.toLeaf(bob.address, weight2)
         await sortition.publicSetLeaf(position2, leaf2, weight2)
         await sortition.publicRemoveLeaf(position1)
-      })
-
-      it("should return correct value for the tree", async () => {
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x1100000000")
       })
@@ -82,23 +73,17 @@ describe("SortitionTree", () => {
     const weightB = 0x10000001
 
     context("when operators are inserted", () => {
-      beforeEach(async () => {
+      it("should return correct value for the tree", async () => {
         await sortition.publicInsertOperator(alice.address, weightA)
         await sortition.publicInsertOperator(bob.address, weightB)
-      })
-
-      it("should return correct value for the tree", async () => {
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x1000fff1")
       })
     })
 
     context("when operator is already registered", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, weightA)
-      })
-
       it("should revert", async () => {
+        await sortition.publicInsertOperator(alice.address, weightA)
         await expect(
           sortition.publicInsertOperator(alice.address, weightB),
         ).to.be.revertedWith("Operator is already registered in the pool")
@@ -108,47 +93,38 @@ describe("SortitionTree", () => {
 
   describe("getOperatorID", () => {
     context("when operator is inserted", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 0xfff0)
-      })
-
       it("should return the id of the operator", async () => {
+        await sortition.publicInsertOperator(alice.address, 0xfff0)
         const aliceID = await sortition.getOperatorID(alice.address)
         expect(aliceID).to.be.equal(1)
       })
+    })
 
-      it("should return zero id when the operator is unknown", async () => {
-        const bobID = await sortition.getOperatorID(bob.address)
-        expect(bobID).to.be.equal(0)
-      })
+    it("should return zero id when the operator is unknown", async () => {
+      const bobID = await sortition.getOperatorID(bob.address)
+      expect(bobID).to.be.equal(0)
     })
   })
 
   describe("getIDOperator", () => {
     context("when operator is inserted", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 0xfff0)
-      })
-
       it("should return the address of the operator by their id", async () => {
+        await sortition.publicInsertOperator(alice.address, 0xfff0)
         const aliceAddress = await sortition.getIDOperator(1)
         expect(aliceAddress).to.be.equal(alice.address)
       })
+    })
 
-      it("should return zero address when the id of operator is unknown", async () => {
-        const aliceAddress = await sortition.getIDOperator(2)
-        expect(aliceAddress).to.be.equal(ZERO_ADDRESS)
-      })
+    it("should return zero address when the id of operator is unknown", async () => {
+      const aliceAddress = await sortition.getIDOperator(2)
+      expect(aliceAddress).to.be.equal(ZERO_ADDRESS)
     })
   })
 
   describe("removeOperator", () => {
     context("when operator is not registered", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 0x1234)
-      })
-
       it("should revert", async () => {
+        await sortition.publicInsertOperator(alice.address, 0x1234)
         await expect(
           sortition.publicRemoveOperator(bob.address),
         ).to.be.revertedWith("Operator is not registered in the pool")
@@ -182,22 +158,16 @@ describe("SortitionTree", () => {
 
   describe("isOperatorRegistered", async () => {
     context("when operator is not registered", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 0x1234)
-      })
-
       it("should return false", async () => {
+        await sortition.publicInsertOperator(alice.address, 0x1234)
         expect(await sortition.publicIsOperatorRegistered(bob.address)).to.be
           .false
       })
     })
 
     context("when operator is registered", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 0x1234)
-      })
-
       it("should return false", async () => {
+        await sortition.publicInsertOperator(alice.address, 0x1234)
         expect(await sortition.publicIsOperatorRegistered(alice.address)).to.be
           .true
       })
@@ -206,12 +176,9 @@ describe("SortitionTree", () => {
 
   describe("updateLeaf", async () => {
     context("when leaf is updated", () => {
-      beforeEach(async () => {
+      it("should return the correct value for the root", async () => {
         await sortition.publicInsertOperator(alice.address, 0x1234)
         await sortition.publicUpdateLeaf(0x00000, 0x9876)
-      })
-
-      it("should return the correct value for the root", async () => {
         const root = await sortition.getRoot()
         expect(ethers.utils.hexlify(root)).to.be.equal("0x9876")
       })
@@ -262,11 +229,8 @@ describe("SortitionTree", () => {
 
   describe("operatorsInPool", async () => {
     context("when the operator is in the pool", () => {
-      beforeEach(async () => {
-        await sortition.publicInsertOperator(alice.address, 1)
-      })
-
       it("should return true", async () => {
+        await sortition.publicInsertOperator(alice.address, 1)
         const nOperators = await sortition.operatorsInPool()
         expect(nOperators).to.be.equal(1)
       })

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -286,12 +286,14 @@ describe("SortitionTree", () => {
   })
 
   describe("operatorsInPool", async () => {
-    context("when the operator is in the pool", () => {
-      it("should return true", async () => {
-        await sortition.publicInsertOperator(alice.address, 1)
-        const nOperators = await sortition.operatorsInPool()
-        expect(nOperators).to.be.equal(1)
-      })
+    it("counts the number of operators in the pool", async () => {
+      await sortition.publicInsertOperator(alice.address, 1)
+      const justAlice = await sortition.operatorsInPool()
+      expect(justAlice).to.be.equal(1)
+
+      await sortition.publicInsertOperator(bob.address, 1)
+      const aliceAndBob = await sortition.operatorsInPool()
+      expect(aliceAndBob).to.be.equal(2)
     })
   })
 

--- a/test/sortitionTreeTest.js
+++ b/test/sortitionTreeTest.js
@@ -238,19 +238,24 @@ describe("SortitionTree", () => {
 
   describe("trunk stacks", async () => {
     it("works as expected", async () => {
+      // inserted in the first position
       await sortition.publicInsertOperator(alice.address, 0x1234)
+      // inserted in the second position
       await sortition.publicInsertOperator(bob.address, 0x9876)
 
       await sortition.publicRemoveOperator(alice.address)
       const deletedLeaf = await sortition.getLeaf(0x00000)
       expect(deletedLeaf).to.be.equal(0)
 
+      // the first position isn't reused until we've inserted 8^7 = 2097152
+      // operators. Alice is inserted in the third position.
       await sortition.publicInsertOperator(alice.address, 0xdead)
 
       const stillDeletedLeaf = await sortition.getLeaf(0x00000)
       expect(stillDeletedLeaf).to.be.equal(0)
 
       const root = await sortition.getRoot()
+      // 0x9876 + 0xdead = 0x17723
       expect(ethers.utils.hexlify(root)).to.be.equal("0x017723")
     })
   })


### PR DESCRIPTION
This PR overhauls the sortition tree tests!

Summary of changes:

+ Simplified the test layout (removed unnecessary `beforeEach` constructions)
+ Simplified the `position` constructions to make it more human-readable
+ Heavily annotated the tests
+ Added some additional specs where the assertions seemed sparse

It might be useful to review commit by commit

Tagging @eth-r @lukasz-zimnoch @pdyraga