### PR TITLE
Restore reward eligibility by operator address

### DIFF
--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -72,13 +72,13 @@ contract Rewards {
   }
 
   /// @notice Return whether the operator is eligible for rewards or not.
-  function isEligibleForRewards(uint32 operator) public view returns (bool) {
+  function isEligibleForRewards(uint32 operator) internal view returns (bool) {
     return operatorRewards[operator].ineligibleUntil == 0;
   }
 
   /// @notice Return the time the operator's reward eligibility can be restored.
   function rewardsEligibilityRestorableAt(uint32 operator)
-    public
+    internal
     view
     returns (uint256)
   {
@@ -87,10 +87,10 @@ contract Rewards {
     return (uint256(until) + ineligibleOffsetStart);
   }
 
-  /// @notice Return whether the operator is able
-  /// to restore their eligibility for rewards right away.
+  /// @notice Return whether the operator is able to restore their eligibility
+  ///         for rewards right away.
   function canRestoreRewardEligibility(uint32 operator)
-    public
+    internal
     view
     returns (bool)
   {

--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -137,6 +137,8 @@ contract SortitionPool is SortitionTree, Rewards, Ownable, IReceiveApproval {
     }
   }
 
+  /// @notice Set the given operators as ineligible for rewards.
+  ///         The operators can restore their eligibility at the given time.
   function setRewardIneligibility(uint32[] calldata operators, uint256 until)
     public
     onlyOwner
@@ -145,10 +147,38 @@ contract SortitionPool is SortitionTree, Rewards, Ownable, IReceiveApproval {
     emit IneligibleForRewards(operators, until);
   }
 
+  /// @notice Restores reward eligibility for the operator.
   function restoreRewardEligibility(address operator) public {
     uint32 id = getOperatorID(operator);
     Rewards.restoreEligibility(id);
     emit RewardEligibilityRestored(operator, id);
+  }
+
+  /// @notice Returns whether the operator is eligible for rewards or not.
+  function isEligibleForRewards(address operator) public view returns (bool) {
+    uint32 id = getOperatorID(operator);
+    return Rewards.isEligibleForRewards(id);
+  }
+
+  /// @notice Returns the time the operator's reward eligibility can be restored.
+  function rewardsEligibilityRestorableAt(address operator)
+    public
+    view
+    returns (uint256)
+  {
+    uint32 id = getOperatorID(operator);
+    return Rewards.rewardsEligibilityRestorableAt(id);
+  }
+
+  /// @notice Returns whether the operator is able to restore their eligibility
+  ///         for rewards right away.
+  function canRestoreRewardEligibility(address operator)
+    public
+    view
+    returns (bool)
+  {
+    uint32 id = getOperatorID(operator);
+    return Rewards.canRestoreRewardEligibility(id);
   }
 
   /// @notice Returns the amount of rewards withdrawable for the given operator.

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -378,17 +378,38 @@ describe("SortitionPool", () => {
       expect(ineligibleReward).to.equal(200)
     })
 
-    it("sets operator ineligibility correctly", async () => {
+    it("sets and restores operator eligibility correctly", async () => {
       await token.connect(deployer).mint(deployer.address, 1000)
       await pool.connect(owner).insertOperator(alice.address, 10000)
       await pool.connect(owner).insertOperator(bob.address, 20000)
+
       const now = await helpers.time.lastBlockTime()
       const bobID = await pool.getOperatorID(bob.address)
+
       await pool.connect(owner).setRewardIneligibility([bobID], now + 100)
+
+      await expect(await pool.isEligibleForRewards(bob.address)).to.be.false
+      await expect(await pool.isEligibleForRewards(alice.address)).to.be.true
+
+      await expect(await pool.canRestoreRewardEligibility(bob.address)).to.be
+        .false
+      await expect(
+        await pool.rewardsEligibilityRestorableAt(bob.address),
+      ).to.equal(now + 100)
 
       await expect(
         pool.restoreRewardEligibility(bob.address),
       ).to.be.revertedWith("Operator still ineligible")
+
+      // Ineligibility is set for a duration. Bob was ineligible for 100
+      // seconds, so we move forward 101 seconds to allow us to make him
+      // eligible again.
+      await helpers.time.increaseTime(101)
+
+      await expect(await pool.canRestoreRewardEligibility(bob.address)).to.be
+        .true
+      await pool.restoreRewardEligibility(bob.address)
+      await expect(await pool.isEligibleForRewards(bob.address)).to.be.true
     })
 
     it("can set many operators ineligible", async () => {

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -388,14 +388,13 @@ describe("SortitionPool", () => {
 
       await pool.connect(owner).setRewardIneligibility([bobID], now + 100)
 
-      await expect(await pool.isEligibleForRewards(bob.address)).to.be.false
-      await expect(await pool.isEligibleForRewards(alice.address)).to.be.true
+      expect(await pool.isEligibleForRewards(bob.address)).to.be.false
+      expect(await pool.isEligibleForRewards(alice.address)).to.be.true
 
-      await expect(await pool.canRestoreRewardEligibility(bob.address)).to.be
-        .false
-      await expect(
-        await pool.rewardsEligibilityRestorableAt(bob.address),
-      ).to.equal(now + 100)
+      expect(await pool.canRestoreRewardEligibility(bob.address)).to.be.false
+      expect(await pool.rewardsEligibilityRestorableAt(bob.address)).to.equal(
+        now + 100,
+      )
 
       await expect(
         pool.restoreRewardEligibility(bob.address),
@@ -406,10 +405,9 @@ describe("SortitionPool", () => {
       // eligible again.
       await helpers.time.increaseTime(101)
 
-      await expect(await pool.canRestoreRewardEligibility(bob.address)).to.be
-        .true
+      expect(await pool.canRestoreRewardEligibility(bob.address)).to.be.true
       await pool.restoreRewardEligibility(bob.address)
-      await expect(await pool.isEligibleForRewards(bob.address)).to.be.true
+      expect(await pool.isEligibleForRewards(bob.address)).to.be.true
     })
 
     it("can set many operators ineligible", async () => {


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/3008

The off-chain client can monitor the reward eligibility and restore it when the
time comes but it is easier for the client to use the operator address instead
of the operator ID.

Looking at the public API so far, the reward eligibility was getting restored
using the address so it makes sense to have all other reward-eligibility-related
functions use the operator address as well, for consistency.