### PR TITLE
TEST FORK: Disable onlyUnlocked for insertOperator

### DIFF
--- a/contracts/SortitionPool.sol
+++ b/contracts/SortitionPool.sol
@@ -105,7 +105,9 @@ contract SortitionPool is SortitionTree, Rewards, Ownable, IReceiveApproval {
   function insertOperator(address operator, uint256 authorizedStake)
     public
     onlyOwner
-    onlyUnlocked
+  // TODO: Disabled temporarily for a test environment. This should never be disabled
+  // in normal circumstances.
+  // onlyUnlocked
   {
     uint256 weight = getWeight(authorizedStake);
     require(weight > 0, "Operator not eligible");


### PR DESCRIPTION
For test environment we want to disable onlyUnlocked for insertOperator
to let operators join the sortion pool anytime, even if DKG is currently
in progress.

DO NOT MERGE THIS COMMIT TO THE MAIN BRANCH!