### PR TITLE
Fixed a check for non-zero weight when allocating rewards

### DIFF
--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -100,7 +100,7 @@ contract Rewards {
 
   /// @notice Internal function for updating the global state of rewards.
   function addRewards(uint96 rewardAmount, uint32 currentPoolWeight) internal {
-    require(currentPoolWeight >= 0, "No recipients in pool");
+    require(currentPoolWeight > 0, "No recipients in pool");
 
     uint96 totalAmount = rewardAmount + rewardRoundingDust;
     uint96 perWeightReward = totalAmount / currentPoolWeight;

--- a/test/sortitionPoolTest.js
+++ b/test/sortitionPoolTest.js
@@ -280,6 +280,13 @@ describe("SortitionPool", () => {
       ).to.be.revertedWith("Ownable: caller is not the owner")
     })
 
+    it("can not be allocated for an empty pool", async () => {
+      await token.connect(deployer).mint(deployer.address, 1000)
+      await expect(
+        token.connect(deployer).approveAndCall(pool.address, 300, []),
+      ).to.be.revertedWith("No recipients in pool")
+    })
+
     it("pays rewards correctly", async () => {
       await token.connect(deployer).mint(deployer.address, 1000)
       await pool.connect(owner).insertOperator(alice.address, 10000)


### PR DESCRIPTION
We expect the pool weight to be non-zero so that we do not allocate rewards to
an empty pool. The condition checking `currentPoolWeight >= 0` was incorrect
given `== 0` case is exactly what we want to avoid. The transaction would fail
later on `totalAmount / currentPoolWeight` but human-readable revert was the
intention of this `require` check.