### PR TITLE
Add the status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sortition Pools
 
+[![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/keep-network/sortition-pools/Test%20Solidity?event=schedule&label=Solidity%20tests)](https://github.com/keep-network/sortition-pools/actions/workflows/solidity-test.yml) 
+
 Sortition pool is a logarithmic data structure used to store the pool of
 eligible operators weighted by their stakes. In the Keep network the stake
 consists of staked KEEP tokens. It allows to select a group of operators based


### PR DESCRIPTION
We're adding a badge to the README file which shows the status of the workflow testing the Solidity code in the `sortition-pools` repository. The displayed status is based the status of the most recently executed `Test Solidity` workflow triggered by the cron.

Refs:
https://github.com/threshold-network/token-dashboard/pull/296
https://github.com/keep-network/coverage-pools/pull/218
https://github.com/keep-network/keep-common/pull/108
https://github.com/keep-network/keep-core/pull/3398
https://github.com/keep-network/tbtc-v2/pull/420