### PR TITLE
Fix badges after change in shields.io syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sortition Pools
 
-[![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/keep-network/sortition-pools/Test%20Solidity?event=schedule&label=Solidity%20tests)](https://github.com/keep-network/sortition-pools/actions/workflows/solidity-test.yml) 
+[![GitHub Workflow Status (event)](https://img.shields.io/github/actions/workflow/status/keep-network/sortition-pools/solidity-test.yml?branch=main&event=schedule&label=Solidity%20tests)](https://github.com/keep-network/sortition-pools/actions/workflows/solidity-test.yml) 
 
 Sortition pool is a logarithmic data structure used to store the pool of
 eligible operators weighted by their stakes. In the Keep network the stake


### PR DESCRIPTION
The `shields.io` have changed the syntax of the endpoints generating status badges, resulting in showing false failure status when old syntax was used. Updating the READMEs to use the new syntax.
Read more: badges/shields#8671.

Refs:
https://github.com/keep-network/keep-common/pull/112
https://github.com/keep-network/keep-core/pull/3449
https://github.com/keep-network/tbtc-v2/pull/429
https://github.com/keep-network/coverage-pools/pull/221